### PR TITLE
Fix get double /features/features/test1.feature for runlevel Scenario…

### DIFF
--- a/framework/scripts/java_autorun.py
+++ b/framework/scripts/java_autorun.py
@@ -360,7 +360,8 @@ class ChimpAutoRun:
         '''
         assert path.isdir(directory), '{} is not exits'.format(directory)
         return [
-            path.join('features', fname)
+            #path.join('features', fname)
+			fname
             for fname in os.listdir(path.join(directory, 'src', 'test', 'resources', 'features'))
             if fname.endswith('.feature')
         ]

--- a/framework/scripts/java_dryrun.py
+++ b/framework/scripts/java_dryrun.py
@@ -19,7 +19,7 @@ def dry_run(projectpath, modules, tags):
         for content in stdout.decode('utf-8').split('\n'):
             if 'Scenario:' in content or 'Scenario Outline:' in content:
                 filepath = content.split('#')[1].strip()
-                filepath_base = '/'.join(filepath.split('/')[-2:])
+                filepath_base = '/'.join(filepath.split('/')[-1:])
                 marray[module].append(filepath_base)
                 count += 1
 


### PR DESCRIPTION
mvn arguments already supplied .../test/resources/features/ + run_file 
but the run_file also contains features/sample.feature.
this results in unable to find the feature file