### PR TITLE
phase-2 + phase-3: dependency hygiene and WebdriverIO async conversion

### DIFF
--- a/framework/libs/browser_session.js
+++ b/framework/libs/browser_session.js
@@ -5,81 +5,82 @@ const encodeUrl = require('encodeurl');
 const defaultTimeout = 15*1000;
 
 module.exports = {
-  resetAll: function(session) {
-    this.resetSession(session);
-    this.resetSize(session);
+  resetAll: async function(session) {
+    await this.resetSession(session);
+    await this.resetSize(session);
   },
 
-  resetSession: function(session) {
-    session.reload();
+  resetSession: async function(session) {
+    await session.reload();
   },
 
-  resetSize: function(session) {
+  resetSize: async function(session) {
     try {
-      session.windowHandleMaximize();
+      await session.windowHandleMaximize();
     } catch(e) {};
   },
 
-  openUrl: function(session, url) {
+  openUrl: async function(session, url) {
     var handle = setInterval(function() {
       session.refresh();
     }, defaultTimeout);
-    session.url(url);
+    await session.url(url);
     clearInterval(handle);
   },
-  
-  clickAndEnter: function(session, linkToClick) {
-    session.$(linkToClick).waitForExist(15000);
+
+  clickAndEnter: async function(session, linkToClick) {
+    await (await session.$(linkToClick)).waitForExist(15000);
     try {
-      session.$(linkToClick).click()
+      await (await session.$(linkToClick)).click();
       try {
-        session.pause(1000);
+        await session.pause(1000);
       } catch(e) {}
     } catch(e) {}
     screen_session.keyTap('enter');
   },
 
-  displayMessage: function(session, displayMsg) {
-    session.url('data:text/plain;charset=utf-8,' + encodeUrl(displayMsg, {charset: 'utf-8'}));
-    session.pause(1000);
+  displayMessage: async function(session, displayMsg) {
+    await session.url('data:text/plain;charset=utf-8,' + encodeUrl(displayMsg, {charset: 'utf-8'}));
+    await session.pause(1000);
   },
 
-  showErrorLog: function(session) {
+  showErrorLog: async function(session) {
     var anyRegexWords = 'failed|rejected|unhandled|unauthorized|error|invalid';
     var msgRegex = RegExp(anyRegexWords);
-    var targetLogArray = session.getLogs('browser').filter(log => msgRegex.test(log.message.toLowerCase()) === true);
+    var targetLogArray = await session.getLogs('browser');
+    targetLogArray = targetLogArray.filter(log => msgRegex.test(log.message.toLowerCase()) === true);
     process.env.LastBrowserLog = JSON.stringify(targetLogArray);
     console.log(process.env.LastBrowserLog);
   },
-  
+
   // wait until DOM content is loaded or timeout
-  waitDOMContentLoaded: function(session, timeout) {
+  waitDOMContentLoaded: async function(session, timeout) {
     var timeout = timeout || defaultTimeout;
     session.getWindowHandle().on('DOMContentLoaded', (event) => {
       return;
     });
-    session.pause(timeout)
+    await session.pause(timeout)
     return;
   },
 
   // wait until Image content is loaded or timeout
-  waitImageContentLoaded: function(session, timeout) {
+  waitImageContentLoaded: async function(session, timeout) {
     var timeout = timeout || defaultTimeout;
     session.getWindowHandle().on('onload', (event) => {
       return;
     });
-    session.pause(timeout)
+    await session.pause(timeout)
     return;
   },
-  
+
   // define bypass chrome warning function
-  bypassChromeWarningIfEncounter: function(session) {
+  bypassChromeWarningIfEncounter: async function(session) {
     try {
-      if (session.$('button=Advanced').waitForExist(3000)) {
-        session.$('button=Advanced').click();
-        session.$('a*=Proceed to').click();
+      if (await (await session.$('button=Advanced')).waitForExist(3000)) {
+        await (await session.$('button=Advanced')).click();
+        await (await session.$('a*=Proceed to')).click();
         return true;
-      }  
+      }
     } catch(e) {
       return false;
     }

--- a/framework/libs/framework_libs.js
+++ b/framework/libs/framework_libs.js
@@ -225,7 +225,7 @@ module.exports = {
         return false;
       }
   },
-  renameRecording: function(scenarioName, resultPrefix) {
+  renameRecording: async function(scenarioName, resultPrefix) {
     const myScenarioName = safeQuote(scenarioName.replace(spaceChar_regex, '_').replace(invalidFileNameChar_regex, ''));
     const myResultPrefix = safeQuote(resultPrefix);
     const scenario_mp4 = this.convertScenarioNameToFileBase(myScenarioName) + '.mp4';
@@ -233,7 +233,7 @@ module.exports = {
     const finalFile_fullPath = `${myReportDir}/${myTestModule}/${myResultPrefix}_${scenario_mp4}`;
     const cmd_rename_movie = 'mv ' + recordingFile_fullPath + ' ' + finalFile_fullPath;
     while (this.recordingRunning(myScenarioName)) {
-      browser.pause(1000);
+      await browser.pause(1000);
     }
     try{
       execSync(cmd_rename_movie);

--- a/framework/libs/fs_session.js
+++ b/framework/libs/fs_session.js
@@ -115,25 +115,18 @@ module.exports = {
     execSync(rm_downloadFile_cmd);
   },
 
-  checkDownloadFile: function(fileName, fileExt) {
+  checkDownloadFile: async function(fileName, fileExt) {
     const filePath = DownloadPathLocal + '/' + fileName + '.' + fileExt;
     while (!fs.existsSync(filePath)) {
-      browser.pause(1000);
+      await browser.pause(1000);
     }
     return filePath;
   },
 
-  readPdfData: function(pdfFullPath) {
+  readPdfData: async function(pdfFullPath) {
     const dataBuffer = fs.readFileSync(pdfFullPath);
-    var pdfData = null;
-    // pdfParse is an async function, need a while-wait statement for pdfData to be filled.
-    pdfParse(dataBuffer).then(function(data) {
-      pdfData = data;
-    });
-    while (pdfData == null) {
-      browser.pause(1000);
-    }
-    return pdfData;
+    // pdfParse is an async function (returns a Promise); await it directly.
+    return await pdfParse(dataBuffer);
   },
 
   readXlsData: function(xlsFullPath) {

--- a/framework/libs/vcenter_session.js
+++ b/framework/libs/vcenter_session.js
@@ -11,19 +11,19 @@ module.exports = {
     },
 
     // define login function
-    loginVcenter: function(session, vCenterURL) {
+    loginVcenter: async function(session, vCenterURL) {
         const [vCenterHost, vCenterUser, vCenterPass] = this.getVcenterInfo(vCenterURL);
-        session.url(`https://${vCenterHost}/ui/`);
-        session.pause(500); 
-        browser_session.bypassChromeWarningIfEncounter(session);
+        await session.url(`https://${vCenterHost}/ui/`);
+        await session.pause(500);
+        await browser_session.bypassChromeWarningIfEncounter(session);
         try {
-            session.$('#username').waitForExist(3000);
-            session.$('#username').setValue(vCenterUser);
-            session.$('#password').setValue(vCenterPass);
-            session.$('#submit').click();
+            await (await session.$('#username')).waitForExist(3000);
+            await (await session.$('#username')).setValue(vCenterUser);
+            await (await session.$('#password')).setValue(vCenterPass);
+            await (await session.$('#submit')).click();
         } catch(e) {}
         try {
-            session.$('.settings').waitForDisplayed(5*1000);
+            await (await session.$('.settings')).waitForDisplayed(5*1000);
             return true;
         } catch(e) {
             return false;
@@ -31,26 +31,26 @@ module.exports = {
     },
 
     // define logout function
-    logoutVcenter: function(session, vCenterURL) {
+    logoutVcenter: async function(session, vCenterURL) {
         const [vCenterHost, vCenterUser, vCenterPass] = this.getVcenterInfo(vCenterURL);
-        session.url(`https://${vCenterHost}/ui/`);
-        session.pause(500);
-        browser_session.bypassChromeWarningIfEncounter(session);
+        await session.url(`https://${vCenterHost}/ui/`);
+        await session.pause(500);
+        await browser_session.bypassChromeWarningIfEncounter(session);
         try {
-            session.$('.nav-icon.user-menu-large').waitForExist(3000);
-            session.$('.nav-icon.user-menu-large').click();
-            session.$('a=Logout').click();
+            await (await session.$('.nav-icon.user-menu-large')).waitForExist(3000);
+            await (await session.$('.nav-icon.user-menu-large')).click();
+            await (await session.$('a=Logout')).click();
         } catch(e) {}
         try {
-            session.$('#password').waitForDisplayed(5*1000);  
+            await (await session.$('#password')).waitForDisplayed(5*1000);
             return true;
         } catch(e) {
             return false;
         }
     },
 
-    reLoginVcenter: function(session, vCenterURL) {
-        this.logoutVcenter(session, vCenterURL);
-        return this.loginVcenter(session, vCenterURL);
+    reLoginVcenter: async function(session, vCenterURL) {
+        await this.logoutVcenter(session, vCenterURL);
+        return await this.loginVcenter(session, vCenterURL);
     },
 }

--- a/framework/step_files/browser/given.js
+++ b/framework/step_files/browser/given.js
@@ -87,8 +87,8 @@ Given(
 
 Given(
     /^(?::browser: )?the page url is( not)* "([^"]*)?"$/,
-    (falseCase, value) => {
-        checkUrl('full URL', falseCase, 'is', value);
+    async (falseCase, value) => {
+        await checkUrl('full URL', falseCase, 'is', value);
     }
 );
 

--- a/framework/step_files/browser/then.js
+++ b/framework/step_files/browser/then.js
@@ -29,61 +29,61 @@ const checkIfElementInsideParentElementEqualsMatchesTextOrValue2 = require(Frame
 const checkIfParentElementEqualsMatchesTextOrValue = require(FrameworkPath + '/framework/step_functions/check/checkIfParentElementEqualsMatchesTextOrValue');
 
 Then(/^(?::browser: )?I expect the( last)* browser console log should( not)* contain "([^"]*)" words$/,
-function (last, falseCase, regexWords) {
+async function (last, falseCase, regexWords) {
     const myRegexWords = regexWords.toLowerCase();
     const anyRegexWords = 'failed|rejected|unhandled|unauthorized|error|invalid';
     const msgRegex = (myRegexWords.indexOf('any error') >= 0) ? RegExp(anyRegexWords) : RegExp(myRegexWords);
-    const targetLogArray = (last) ? JSON.parse(process.env.LastBrowserLog) : browser.getLogs('browser').filter(log => msgRegex.test(log.message.toLowerCase()) === true);
+    const targetLogArray = (last) ? JSON.parse(process.env.LastBrowserLog) : (await browser.getLogs('browser')).filter(log => msgRegex.test(log.message.toLowerCase()) === true);
     process.env.LastBrowserLog = JSON.stringify(targetLogArray);
     console.log(process.env.LastBrowserLog);
     if (falseCase) {
-        expect(targetLogArray.length).not.toBeGreaterThan(0);
+        await expect(targetLogArray.length).not.toBeGreaterThan(0);
     } else {
-        expect(targetLogArray.length).toBeGreaterThan(0);
+        await expect(targetLogArray.length).toBeGreaterThan(0);
     }
 });
 
 Then(/^(?::browser: )?I expect the( last)* browser console (SEVERE) level log does( not)* exist(?: (exactly|not exactly|more than|no more than|less than|at least|no less than) (\d+) time(?:s)?)?$/,
-function (last, logLevel, falseCase, compareAction, expectedNumber) {
+async function (last, logLevel, falseCase, compareAction, expectedNumber) {
     const myExpectedNumber = (expectedNumber) ? parseInt(expectedNumber) : 0;
-    const targetLogArray = (last) ? JSON.parse(process.env.LastBrowserLog) : browser.getLogs('browser').filter(log => log.level == logLevel);
+    const targetLogArray = (last) ? JSON.parse(process.env.LastBrowserLog) : (await browser.getLogs('browser')).filter(log => log.level == logLevel);
     process.env.LastBrowserLog = JSON.stringify(targetLogArray);
     console.log(process.env.LastBrowserLog);
 
     if (!!false) {
-        expect(compareAction).not.toContain('no', 'do not support double negative statement');
-        expect(compareAction).not.toContain('at least', 'do not support no at least statement');
+        await expect(compareAction).not.toContain('no', 'do not support double negative statement');
+        await expect(compareAction).not.toContain('at least', 'do not support no at least statement');
         switch (compareAction) {
             case 'exactly':
-                expect(targetLogArray.length).not.toEqual(parseInt(myExpectedNumber));
+                await expect(targetLogArray.length).not.toEqual(parseInt(myExpectedNumber));
                 break;
             case 'more than':
-                expect(targetLogArray.length).not.toBeGreaterThan(parseInt(myExpectedNumber));
+                await expect(targetLogArray.length).not.toBeGreaterThan(parseInt(myExpectedNumber));
                 break;
             case 'less than':
-                expect(targetLogArray.length).not.toBeLessThan(parseInt(myExpectedNumber));
+                await expect(targetLogArray.length).not.toBeLessThan(parseInt(myExpectedNumber));
                 break;
         }
     } else {
         switch (compareAction) {
             case 'exactly':
-                expect(targetLogArray.length).toEqual(parseInt(myExpectedNumber));
+                await expect(targetLogArray.length).toEqual(parseInt(myExpectedNumber));
                 break;
             case 'not exactly':
-                expect(targetLogArray.length).not.toEqual(parseInt(myExpectedNumber));
+                await expect(targetLogArray.length).not.toEqual(parseInt(myExpectedNumber));
                 break;
             case 'more than':
-                expect(targetLogArray.length).toBeGreaterThan(parseInt(myExpectedNumber));
+                await expect(targetLogArray.length).toBeGreaterThan(parseInt(myExpectedNumber));
                 break;
             case 'no more than':
-                expect(targetLogArray.length).not.toBeGreaterThan(parseInt(myExpectedNumber));
+                await expect(targetLogArray.length).not.toBeGreaterThan(parseInt(myExpectedNumber));
                 break;
             case 'less than':
-                expect(targetLogArray.length).toBeLessThan(parseInt(myExpectedNumber));
+                await expect(targetLogArray.length).toBeLessThan(parseInt(myExpectedNumber));
                 break;
             case 'at least':
             case 'no less than':
-                expect(targetLogArray.length).not.toBeLessThan(parseInt(myExpectedNumber));
+                await expect(targetLogArray.length).not.toBeLessThan(parseInt(myExpectedNumber));
                 break;
         }
     }
@@ -91,24 +91,24 @@ function (last, logLevel, falseCase, compareAction, expectedNumber) {
 
 Then(/^(?::browser: )?I should see the "([^"]*)" (button|label|option|modalDialog) on the page$/,
     { timeout: 60 * 1000 },
-    function (elementText, elementName) {
+    async function (elementText, elementName) {
         const textedElements = require(FrameworkPath + '/framework/testfiles/textedElements');
         const targetElement = eval('textedElements.texted_' + elementName).replace('__TEXT__', elementText);
-        browser.$(targetElement).waitForDisplayed(500);
-        expect(browser.$(targetElement).isDisplayed()).toBe(true);
+        await (await browser.$(targetElement)).waitForDisplayed(500);
+        await expect((await browser.$(targetElement)).isDisplayed()).toBe(true);
     });
 
-Then(/^(?::browser: )?the "([^"]*)" modal\-dialoag should contain these select\-option$/, { timeout: 60 * 1000 }, function (modalText, table) {
+Then(/^(?::browser: )?the "([^"]*)" modal\-dialoag should contain these select\-option$/, { timeout: 60 * 1000 }, async function (modalText, table) {
     const web_selectors = this.web_selectors;
     const seleniumPage_selectors = this.seleniumPage_selectors;
     const myModalDialog = seleniumPage_selectors.texted_modalDialog.replace('__TEXT__', modalText);
     const myModalDialog_select = myModalDialog + web_selectors.select;
     var expected_browserList = table.hashes();
-    var displayed_browserList = browser.$(myModalDialog_select).getText();
-    browser.$(myModalDialog_select).click();
-    expected_browserList.forEach(function (row) {
-        expect(displayed_browserList).toContain(row['browser_name']);
-    });
+    var displayed_browserList = await (await browser.$(myModalDialog_select)).getText();
+    await (await browser.$(myModalDialog_select)).click();
+    for (const row of expected_browserList) {
+        await expect(displayed_browserList).toContain(row['browser_name']);
+    }
 });
 
 Then(

--- a/framework/step_files/browser/when.js
+++ b/framework/step_files/browser/when.js
@@ -25,15 +25,15 @@ const waitForDownload = require(FrameworkPath + '/framework/step_functions/actio
 
 When(/^(?::browser: )?I click the "([^"]*)" (button|label|option|modalDialog) on the page$/,
 { timeout: 60 * 1000 },
-function (elementText, elementName) {
+async function (elementText, elementName) {
     const textedElements = require(FrameworkPath + '/framework/testfiles/textedElements');
     const targetElement = eval('textedElements.texted_' + elementName).replace('__TEXT__', elementText);
     switch (elementName) {
         case 'option':
-            browser.$(targetElement).$('..').click();
+            await (await (await browser.$(targetElement)).$('..')).click();
             break;
         default:
-            browser.$(targetElement).click();
+            await (await browser.$(targetElement)).click();
     }
 });
 

--- a/framework/step_files/maven/given.js
+++ b/framework/step_files/maven/given.js
@@ -11,14 +11,14 @@ Given(/^(?::maven: )?I have a java cucumber project module "([^"]*)"$/, function
     this.javacucumber_projectModule = projectModule;
   });
 
-Given(/^(?::maven: )?I have a java cucumber project "([^"]*)"$/, function (projectName) {
+Given(/^(?::maven: )?I have a java cucumber project "([^"]*)"$/, async function (projectName) {
     this.javacucumber_project = projectName;
     var result = javacucumber_session.runMvnCleanProject(this.javacucumber_project);
     // console.log(result.output);
-    browser_session.displayMessage(browser, result.output);
-    expect(result.output).toContain('BUILD SUCCESS');
-    expect(result.output).not.toContain('BUILD FAILURE');
-    expect(result.exitcode).toBe(0);
+    await browser_session.displayMessage(browser, result.output);
+    await expect(result.output).toContain('BUILD SUCCESS');
+    await expect(result.output).not.toContain('BUILD FAILURE');
+    await expect(result.exitcode).toBe(0);
     this.javacucumber_result = result.output;
     this.javacucumber_runcode = result.exitcode;
   });

--- a/framework/step_files/maven/then.js
+++ b/framework/step_files/maven/then.js
@@ -3,12 +3,12 @@ const { Then } = require('@cucumber/cucumber');
 const FrameworkPath = process.env.FrameworkPath || process.env.HOME + '/Projects/AutoBDD';
 const browser_session = require(FrameworkPath + '/framework/libs/browser_session');
 
-Then(/^(?::maven: )?the java cucumber test should all pass$/, function () {
-    browser_session.displayMessage(browser, this.javacucumber_result);
-    expect(this.javacucumber_result).toContain('BUILD SUCCESS');
-    expect(this.javacucumber_result).not.toContain('BUILD FAILURE');
-    expect(this.javacucumber_result).toContain('Failures: 0, Errors: 0, Skipped: 0');
-    expect(this.javacucumber_runcode).toBe(0);
+Then(/^(?::maven: )?the java cucumber test should all pass$/, async function () {
+    await browser_session.displayMessage(browser, this.javacucumber_result);
+    await expect(this.javacucumber_result).toContain('BUILD SUCCESS');
+    await expect(this.javacucumber_result).not.toContain('BUILD FAILURE');
+    await expect(this.javacucumber_result).toContain('Failures: 0, Errors: 0, Skipped: 0');
+    await expect(this.javacucumber_runcode).toBe(0);
   });
 
 

--- a/framework/step_files/maven/when.js
+++ b/framework/step_files/maven/when.js
@@ -4,13 +4,13 @@ const FrameworkPath = process.env.FrameworkPath || process.env.HOME + '/Projects
 const browser_session = require(FrameworkPath + '/framework/libs/browser_session');
 const javacucumber_session = require(FrameworkPath + '/framework/libs/javacucumber_session');
 
-When(/^(?::maven: )?I run the java cucumber scenario "([^"]*)"$/, {timeout: 60*1000 * 4}, function (javacucumberScenario) {
+When(/^(?::maven: )?I run the java cucumber scenario "([^"]*)"$/, {timeout: 60*1000 * 4}, async function (javacucumberScenario) {
         var result = javacucumber_session.runMvnTestScenario(this.javacucumber_project,
                                                                     this.javacucumber_projectModule,
                                                                     this.javacucumber_featureFile,
                                                                     javacucumberScenario);
     console.log(result.output);
-    browser_session.displayMessage(browser, result.output);
+    await browser_session.displayMessage(browser, result.output);
     this.javacucumber_result = result.output;
     this.javacucumber_runcode = result.exitcode;
 });

--- a/framework/step_files/nodejs/given.js
+++ b/framework/step_files/nodejs/given.js
@@ -4,8 +4,8 @@ const parseExpectedText = require(`${process.env.FrameworkPath}/framework/step_f
 const { Given } = require('@cucumber/cucumber');
 
 Given(/^(?::nodejs: )?I call (?:(framework|project|module) )?function "([^"]*)?" with parameters "([^"]*)?"(?: and assign ouput as "([^"]*)?")?(?: in order to .*)?$/,
-    (funcType, funcName, funcParms, varName) => {
-            const myParsedParms = parseExpectedText(funcParms)
+    async (funcType, funcName, funcParms, varName) => {
+            const myParsedParms = await parseExpectedText(funcParms)
             let runFunc;
             switch (funcType) {
                 case "framework":

--- a/framework/step_files/postman/then.js
+++ b/framework/step_files/postman/then.js
@@ -3,10 +3,10 @@ const { Then } = require('@cucumber/cucumber');
 const FrameworkPath = process.env.FrameworkPath || process.env.HOME + '/Projects/AutoBDD';
 const browser_session = require(FrameworkPath + '/framework/libs/browser_session');
 
-Then(/^(?::postman: )?the postman test should not have failure$/, function () {
-    browser_session.displayMessage(browser, this.postman_result);
-    expect(this.postman_result).not.toMatch(RegExp('#.*failure.*detail'));
-    expect(this.postman_runcode).toBe(0);
+Then(/^(?::postman: )?the postman test should not have failure$/, async function () {
+    await browser_session.displayMessage(browser, this.postman_result);
+    await expect(this.postman_result).not.toMatch(RegExp('#.*failure.*detail'));
+    await expect(this.postman_runcode).toBe(0);
   });
 
 

--- a/framework/step_files/postman/when.js
+++ b/framework/step_files/postman/when.js
@@ -4,13 +4,13 @@ const FrameworkPath = process.env.FrameworkPath || process.env.HOME + '/Projects
 const browser_session = require(FrameworkPath + '/framework/libs/browser_session');
 const cmdline_session = require(FrameworkPath + '/framework/libs/cmdline_session');
 
-When(/^(?::postman: )?I run the postman collection in newman commandline$/, function () {
+When(/^(?::postman: )?I run the postman collection in newman commandline$/, async function () {
         const newman_command = `newman run -e ${this.postman_environment_file} ${this.postman_collection_file}`;
         console.log(newman_command);
         const newman_result = cmdline_session.runCmd(newman_command);
         let result = JSON.parse(newman_result);
         console.log(result.output);
-        browser_session.displayMessage(browser, result.output);
+        await browser_session.displayMessage(browser, result.output);
         this.postman_result = result.output;
         this.postman_runcode = result.exitcode;
 });

--- a/framework/step_files/screen/then.js
+++ b/framework/step_files/screen/then.js
@@ -8,7 +8,7 @@ const fuzz = require('fuzzball');
 
 Then(/^(?::screen: )?I expect (?:that )?the "([^"]*)?" image does( not)* appear(?: (exactly|not exactly|more than|no more than|less than|no less than) (\d+) time(?:s)?)?$/,
 { timeout: 60 * 1000 },
-function (imageName, falseCase, compareAction, expectedNumber) {
+async function (imageName, falseCase, compareAction, expectedNumber) {
     const parsedImageName = parseExpectedText(imageName);
     const myExpectedNumber = (expectedNumber) ? parseInt(expectedNumber) : 0;
     const myCompareAction = compareAction || ((typeof falseCase == 'undefined') ? 'more than' : 'exactly');
@@ -34,32 +34,32 @@ function (imageName, falseCase, compareAction, expectedNumber) {
     }
     switch (myCompareAction) {
         case 'exactly':
-            expect(screenFindResult.length).toEqual(parseInt(myExpectedNumber));
+            await expect(screenFindResult.length).toEqual(parseInt(myExpectedNumber));
             break;
         case 'not exactly':
-            expect(typeof falseCase === 'undefined').toBe(true, 'cannot use double negative expression');
-            expect(screenFindResult.length).not.toEqual(parseInt(myExpectedNumber));
+            await expect(typeof falseCase === 'undefined').toBe(true, 'cannot use double negative expression');
+            await expect(screenFindResult.length).not.toEqual(parseInt(myExpectedNumber));
             break;
         case 'more than':
-            expect(screenFindResult.length).toBeGreaterThan(parseInt(myExpectedNumber));
+            await expect(screenFindResult.length).toBeGreaterThan(parseInt(myExpectedNumber));
             break;
         case 'no more than':
-            expect(typeof falseCase === 'undefined').toBe(true, 'cannot use double negative expression');
-            expect(screenFindResult.length).not.toBeGreaterThan(parseInt(myExpectedNumber));
+            await expect(typeof falseCase === 'undefined').toBe(true, 'cannot use double negative expression');
+            await expect(screenFindResult.length).not.toBeGreaterThan(parseInt(myExpectedNumber));
             break;
         case 'less than':
-            expect(screenFindResult.length).toBeLessThan(parseInt(myExpectedNumber));
+            await expect(screenFindResult.length).toBeLessThan(parseInt(myExpectedNumber));
             break;
         case 'no less than':
-            expect(typeof falseCase === 'undefined').toBe(true, 'cannot use double negative expression');
-            expect(screenFindResult.length).not.toBeLessThan(parseInt(myExpectedNumber));
+            await expect(typeof falseCase === 'undefined').toBe(true, 'cannot use double negative expression');
+            await expect(screenFindResult.length).not.toBeLessThan(parseInt(myExpectedNumber));
             break;
     }
 });
 
 Then(/^(?::screen: )?I expect (?:that )?(?:the( first| last)? (\d+)(?:st|nd|rd|th)? line(?:s)? of )?the (?:"([^"]*)?" )?(image|screen area) does( not)* (contain|equal|mimic|match) the (text|regex) "(.*)?"$/,
     { timeout: 60 * 1000 },
-    function (firstOrLast, lineCount, targetName, targetArea, falseCase, compareAction, expectType, expectedText) {
+    async function (firstOrLast, lineCount, targetName, targetArea, falseCase, compareAction, expectType, expectedText) {
         const myExpectedText = parseExpectedText(expectedText);
         const myFirstOrLast = firstOrLast || '';
 
@@ -111,72 +111,72 @@ Then(/^(?::screen: )?I expect (?:that )?(?:the( first| last)? (\d+)(?:st|nd|rd|t
         if (boolFalseCase) {
             switch (compareAction) {
                 case 'contain':
-                    expect(lineText).not.toContain(
+                    await expect(lineText).not.toContain(
                         myExpectedText,
                         `target image text should not contain the ${expectType} ` +
                         `"${myExpectedText}"`
                     );
                     break;
                 case 'equal':
-                    expect(lineText).not.toEqual(
+                    await expect(lineText).not.toEqual(
                         myExpectedText,
                         `target image text should not equal the ${expectType} ` +
                         `"${myExpectedText}"`
                     );
                     break;
                 case 'mimic':
-                    expect(mimicScore).not.toBeGreaterThanOrEqual(60,
+                    await expect(mimicScore).not.toBeGreaterThanOrEqual(60,
                         `target image text should not mimic the ${expectType} ` +
                         `"${myExpectedText}"`
                     );
                     break;
                 case 'match':
-                    expect(lineText.toLowerCase()).not.toMatch(
+                    await expect(lineText.toLowerCase()).not.toMatch(
                         RegExp(myExpectedText.toLowerCase()),
                         `target image text should not match the ${expectType} ` +
                         `"${myExpectedText}"`
                     );
                     break;
                 default:
-                    expect(false).toBe(true, `compareAction ${compareAction} should be one of contain, equal or match`);
+                    await expect(false).toBe(true, `compareAction ${compareAction} should be one of contain, equal or match`);
             }
         } else {
             switch (compareAction) {
                 case 'contain':
-                    expect(lineText).toContain(
+                    await expect(lineText).toContain(
                         myExpectedText,
                         `target image text should contain the ${expectType} ` +
                         `"${myExpectedText}"`
                     );
                     break;
                 case 'equal':
-                    expect(lineText).toEqual(
+                    await expect(lineText).toEqual(
                         myExpectedText,
                         `target image text should equal the ${expectType} ` +
                         `"${myExpectedText}"`
                     );
                     break;
                 case 'mimic':
-                    expect(mimicScore).toBeGreaterThanOrEqual(60,
+                    await expect(mimicScore).toBeGreaterThanOrEqual(60,
                         `target image text should mimic the ${expectType} ` +
                         `"${myExpectedText}"`
                     );
                     break;
                 case 'match':
-                    expect(lineText.toLowerCase()).toMatch(
+                    await expect(lineText.toLowerCase()).toMatch(
                         RegExp(myExpectedText.toLowerCase()),
                         `target image text should match the ${expectType} ` +
                         `"${myExpectedText}"`
                     );
                     break;
                 default:
-                    expect(false).toBe(true, `compareAction ${compareAction} should be one of contain, equal or match`);
+                    await expect(false).toBe(true, `compareAction ${compareAction} should be one of contain, equal or match`);
             }
         }
     }
 );
 
-Then(/^(?::screen: )?I should(?: still)?( not)* see the "([^"]*)" image on the screen$/, { timeout: 60 * 1000 }, function (falseCase, imageName) {
+Then(/^(?::screen: )?I should(?: still)?( not)* see the "([^"]*)" image on the screen$/, { timeout: 60 * 1000 }, async function (falseCase, imageName) {
     const parsedImageName = parseExpectedText(imageName);
     const [imageFileName, imageFileExt, imageSimilarity, maxSimilarityOrText] = fs_session.getTestImageParms(parsedImageName);
     const imagePathList = fs_session.globalSearchImageList(__dirname, imageFileName, imageFileExt);
@@ -184,9 +184,9 @@ Then(/^(?::screen: )?I should(?: still)?( not)* see the "([^"]*)" image on the s
     var screenFindResult = JSON.parse(screen_session.screenFindImage(imagePathList, imageScore, maxSimilarityOrText));
     console.log(screenFindResult);
     if (falseCase) {
-        expect(screenFindResult.length).toEqual(0, `expect image ${parsedImageName} not on the screen but found.`);
+        await expect(screenFindResult.length).toEqual(0, `expect image ${parsedImageName} not on the screen but found.`);
     } else {
-        expect(screenFindResult.length).not.toEqual(0, `expect image ${parsedImageName} on the screen but not found.`);
+        await expect(screenFindResult.length).not.toEqual(0, `expect image ${parsedImageName} on the screen but not found.`);
         this.lastSeen_screenFindResult = screenFindResult;
         // console.log(this.lastSeen_screenFindResult);
     }

--- a/framework/step_files/screen/when.js
+++ b/framework/step_files/screen/when.js
@@ -35,9 +35,9 @@ When(/^(?::screen: )?I select the "([^"]*)?" file for upload$/, {timeout: 300*10
 });
   
 When(/^(?::screen: )?I download the (PDF) file by clicking "([^"]*)"$/, { timeout: 60 * 1000 * 2 },
-function (fileType, imageName) {
+async function (fileType, imageName) {
     // delete previous download file
-    var downloadUrl = browser.getUrl();
+    var downloadUrl = await browser.getUrl();
     var fileName = decodeURI(downloadUrl.substring(downloadUrl.lastIndexOf('/') + 1, downloadUrl.lastIndexOf('.')));
     var fileExt = decodeURI(downloadUrl.substring(downloadUrl.lastIndexOf('.') + 1));
     fs_session.deleteDownloadFile(fileName, fileExt);
@@ -55,7 +55,7 @@ function (fileType, imageName) {
     // click PDF download icon
     var screenActionResultOne;
     screenActionResultOne = JSON.parse(screen_session.screenClickImage(imagePathListOne, imageSimilarityOne, maxSimilarityOrTextOne));
-    expect(screenActionResultOne.length).not.toEqual(0, 'failed to click PDF download icon');
+    await expect(screenActionResultOne.length).not.toEqual(0, 'failed to click PDF download icon');
 
     // process FileSave_button
     const parsedImageNameTwo = parseExpectedText('FileSave_button:save');
@@ -63,23 +63,23 @@ function (fileType, imageName) {
     const imagePathListTwo = fs_session.globalSearchImageList(__dirname, imageFileNametwo, imageFileExtTwo);
     // click FileSave_button
     screenActionResult = JSON.parse(screen_session.screenClickImage(imagePathListTwo, imageSimilarityTwo, maxSimilarityOrTextTwo));
-    expect(screenActionResult.length).not.toEqual(0, 'failed to click FileSave button');
-    const downloadFilePath = fs_session.checkDownloadFile(fileName, fileExt);
-    expect(downloadFilePath).toContain(fileName + '.' + fileExt);
+    await expect(screenActionResult.length).not.toEqual(0, 'failed to click FileSave button');
+    const downloadFilePath = await fs_session.checkDownloadFile(fileName, fileExt);
+    await expect(downloadFilePath).toContain(fileName + '.' + fileExt);
 });
 
 When(/^(?::screen: )?I download the (XLS|PDF) file by going to URL "([^"]*)"$/,
 { timeout: 60 * 1000 * 2 },
-function (fileType, downloadUrl) {
+async function (fileType, downloadUrl) {
     // delete previous download file
     var fileName = decodeURI(downloadUrl.substring(downloadUrl.lastIndexOf('/') + 1, downloadUrl.lastIndexOf('.')));
     var fileExt = decodeURI(downloadUrl.substring(downloadUrl.lastIndexOf('.') + 1));
     fs_session.deleteDownloadFile(fileName, fileExt);
 
     // download file from URL
-    browser.url(downloadUrl)
-    var downloadFilePath = fs_session.checkDownloadFile(fileName, fileExt);
-    expect(downloadFilePath).toContain(fileName + '.' + fileExt);
+    await browser.url(downloadUrl)
+    var downloadFilePath = await fs_session.checkDownloadFile(fileName, fileExt);
+    await expect(downloadFilePath).toContain(fileName + '.' + fileExt);
     // pass download Url for steps after
     this.downloadUrl = downloadUrl;
 });
@@ -90,7 +90,7 @@ When(
 );
 
 When(/^(?::screen: )?I drag "([^"]*)" and drop to "([^"]*)"$/,
-function (imageNameOne, imageNameTwo) {
+async function (imageNameOne, imageNameTwo) {
     // re imageNameOne
     const parsedImageNameOne = parseExpectedText(imageNameOne);
     const [imageFileNameOne, imageFileExtOne, imageSimilarityOne, maxSimilarityOrTextOne] = fs_session.getTestImageParms(parsedImageNameOne);
@@ -111,17 +111,17 @@ function (imageNameOne, imageNameTwo) {
     }
 
     var locationOne = JSON.parse(screen_session.screenFindImage(imagePathListOne, imageSimilarityOne, maxSimilarityOrTextOne));
-    expect(locationOne.length).not.toEqual(0, `can not locate the "${imageNameOne}" image on the screen`);
+    await expect(locationOne.length).not.toEqual(0, `can not locate the "${imageNameOne}" image on the screen`);
     var locationTwo = JSON.parse(screen_session.screenFindImage(imagePathListTwo, imageSimilarityTwo, maxSimilarityOrTextTwo));
-    expect(locationTwo.length).not.toEqual(0, `can not locate the "${imageNameTwo}" image on the screen`);
+    await expect(locationTwo.length).not.toEqual(0, `can not locate the "${imageNameTwo}" image on the screen`);
     screen_session.drag_and_drop(locationOne[0].center, locationTwo[0].center);
-    browser.pause(1000);
+    await browser.pause(1000);
 });
 
 
 When(/^(?::screen: )?I (circle|click|expect|park|hover|shake|wave) mouse(?: (\d+) times)? at the (center|centerLeft|centerRight|bottomCenter|bottomLeft|bottomRight|previous|topCenter|topLeft|topRight|\d+,\d+) position of the screen$/,
 { timeout: 60 * 1000 },
-function (mouseAction, timesCount, screenLocation) {
+async function (mouseAction, timesCount, screenLocation) {
     const myDISPLAYSIZE = process.env.DISPLAYSIZE;
     const [myScreenX, myScreenY] = myDISPLAYSIZE.split('x');
     var targetLocation = { x: 0, y: 0 };
@@ -183,8 +183,8 @@ function (mouseAction, timesCount, screenLocation) {
                 const mousePos = JSON.parse(screen_session.getMousePos());
                 const deltaX = Math.abs(mousePos.x - targetLocation.x);
                 const deltaY = Math.abs(mousePos.y - targetLocation.y);
-                expect(deltaX).not.toBeGreaterThan(5);
-                expect(deltaY).not.toBeGreaterThan(5);
+                await expect(deltaX).not.toBeGreaterThan(5);
+                await expect(deltaY).not.toBeGreaterThan(5);
                 break;
             case 'move':
             case 'park':
@@ -226,7 +226,7 @@ function (mouseAction, timesCount, screenLocation) {
 
 When(/^(?::screen: )?I wait (?:(?:every (\d+) seconds for )?(\d+) minute(?:s)? )?on (?:the (first|last) (\d+) line(?:s)? of )?the (?:"([^"]*)?" image|screen area) to( not)* display the (text|regex) "(.*)?"$/,
 { timeout: 60 * 60 * 1000 },
-function (waitIntvSec, waitTimeoutMnt, firstOrLast, lineCount, targetName, falseState, expectType, expectedText) {
+async function (waitIntvSec, waitTimeoutMnt, firstOrLast, lineCount, targetName, falseState, expectType, expectedText) {
     // parse input
     const myExpectedText = parseExpectedText(expectedText);
     const myWaitTimeoutMnt = parseInt(waitTimeoutMnt) || 1;
@@ -265,7 +265,7 @@ function (waitIntvSec, waitTimeoutMnt, firstOrLast, lineCount, targetName, false
     var screenFindResult;
     do {
         // wait
-        browser.pause(myWaitIntvSec * 1000)
+        await browser.pause(myWaitIntvSec * 1000)
         // check
         if (targetName) {
             screenFindResult = JSON.parse(screen_session.screenFindImage(imagePathList, imageScore, maxSimilarityOrText));
@@ -312,7 +312,7 @@ function (waitIntvSec, waitTimeoutMnt, firstOrLast, lineCount, targetName, false
 
 When(/^(?::screen: )?I (click|hoverClick|rightClick|doubleClick|hover|wave|shake|circle)(?: (\d+) times)? (on|between) the "([^"]*)" image(?: and the "([^"]*)" image)? on the screen$/,
 { timeout: 60 * 1000 },
-function (mouseAction, timesCount, targetType, imageNameOne, imageNameTwo) {
+async function (mouseAction, timesCount, targetType, imageNameOne, imageNameTwo) {
     // re imageNameOne
     const parsedImageNameOne = parseExpectedText(imageNameOne);
     const [imageFileNameOne, imageFileExtOne, imageSimilarityOne, maxSimilarityOrTextOne] = fs_session.getTestImageParms(parsedImageNameOne);
@@ -337,9 +337,9 @@ function (mouseAction, timesCount, targetType, imageNameOne, imageNameTwo) {
             var locationOne, locationTwo;
             var targetLocation = {};
             locationOne = JSON.parse(screen_session.screenFindImage(imagePathListOne, imageSimilarityOne, maxSimilarityOrTextOne));
-            expect(locationOne.length).not.toEqual(0, `can not locate the "${imageNameOne}" image on the screen`);
+            await expect(locationOne.length).not.toEqual(0, `can not locate the "${imageNameOne}" image on the screen`);
             locationTwo = JSON.parse(screen_session.screenFindImage(imagePathListTwo, imageSimilarityTwo, maxSimilarityOrTextTwo));
-            expect(locationTwo.length).not.toEqual(0, `can not locate the "${imageNameTwo}" image on the screen`);
+            await expect(locationTwo.length).not.toEqual(0, `can not locate the "${imageNameTwo}" image on the screen`);
             targetLocation.x = (locationOne[0].center.x + locationTwo[0].center.x) / 2;
             targetLocation.y = (locationOne[0].center.y + locationTwo[0].center.y) / 2;
             var myTimesCount = timesCount || 1;
@@ -458,7 +458,7 @@ function (mouseAction, timesCount, targetType, imageNameOne, imageNameTwo) {
                 myTimesCount--;
             }
             console.log(screenFindResult);
-            expect(screenFindResult.length).not.toEqual(0, `can not ${mouseAction} the "${imageNameOne}" image on the screen`);
+            await expect(screenFindResult.length).not.toEqual(0, `can not ${mouseAction} the "${imageNameOne}" image on the screen`);
             break;
     }
 });

--- a/framework/step_files/shell/then.js
+++ b/framework/step_files/shell/then.js
@@ -7,17 +7,17 @@ const stripAnsi = require('strip-ansi-control-characters');
 
 Then(/^(?::shell: )?I expect (?:that )?(?:the( first| last)? (\d+)(?:st|nd|rd|th)? line(?:s)? of )?the "(.*)?" console does( not)* (contain|equal|match) the (text|regex) "(.*)?"$/,
     { timeout: 60 * 1000 },
-    function (firstOrLast, lineCount, consoleName, falseCase, compareAction, expectType, expectedText) {
+    async function (firstOrLast, lineCount, consoleName, falseCase, compareAction, expectType, expectedText) {
         // parse input
         const myConsoleName = parseExpectedText(consoleName);
         const myExpectedText = parseExpectedText(expectedText);
         const myFirstOrLast = firstOrLast || '';
 
         // get consoleData object set up by previous step
-        browser.pause(500);
+        await browser.pause(500);
         const myConsoleData = this.myConsoleData;
         const lineArray = stripAnsi.string(myConsoleData[myConsoleName].stdout).split(/[\r\n]+/);
-        browser_session.displayMessage(browser, lineArray.join('\n'));
+        await browser_session.displayMessage(browser, lineArray.join('\n'));
 
         var lineText;
         switch (myFirstOrLast.trim()) {
@@ -39,54 +39,54 @@ Then(/^(?::shell: )?I expect (?:that )?(?:the( first| last)? (\d+)(?:st|nd|rd|th
         if (boolFalseCase) {
             switch (compareAction) {
                 case 'contain':
-                    expect(lineText).not.toContain(
+                    await expect(lineText).not.toContain(
                         myExpectedText,
                         `console should not contain the ${expectType} ` +
                         `"${myExpectedText}"`
                     );
                     break;
                 case 'equal':
-                    expect(lineText).not.toEqual(
+                    await expect(lineText).not.toEqual(
                         myExpectedText,
                         `console should not equal the ${expectType} ` +
                         `"${myExpectedText}"`
                     );
                     break;
                 case 'match':
-                    expect(lineText.toLowerCase()).not.toMatch(
+                    await expect(lineText.toLowerCase()).not.toMatch(
                         RegExp(myExpectedText.toLowerCase()),
                         `console should match the ${expectType} ` +
                         `"${myExpectedText}"`
                     );
                     break;
                 default:
-                    expect(false).toBe(true, `compareAction ${compareAction} should be one of contain, equal or match`);
+                    await expect(false).toBe(true, `compareAction ${compareAction} should be one of contain, equal or match`);
             }
         } else {
             switch (compareAction) {
                 case 'contain':
-                    expect(lineText).toContain(
+                    await expect(lineText).toContain(
                         myExpectedText,
                         `console should contain the ${expectType} ` +
                         `"${myExpectedText}"`
                     );
                     break;
                 case 'equal':
-                    expect(lineText).toEqual(
+                    await expect(lineText).toEqual(
                         myExpectedText,
                         `console should equal the ${expectType} ` +
                         `"${myExpectedText}"`
                     );
                     break;
                 case 'match':
-                    expect(lineText.toLowerCase()).toMatch(
+                    await expect(lineText.toLowerCase()).toMatch(
                         RegExp(myExpectedText.toLowerCase()),
                         `console should match the ${expectType} ` +
                         `"${myExpectedText}"`
                     );
                     break;
                 default:
-                    expect(false).toBe(true, `compareAction ${compareAction} should be one of contain, equal or match`);
+                    await expect(false).toBe(true, `compareAction ${compareAction} should be one of contain, equal or match`);
             }
         }
     }

--- a/framework/step_files/shell/when.js
+++ b/framework/step_files/shell/when.js
@@ -48,7 +48,7 @@ function (consoleName) {
 
 When(/^(?::shell: )?I copy (test file|downloaded file|folder) "(.*)" to scp target "(.*)" with password "(.*)"$/,
 { timeout: 15 * 60 * 1000 },
-function (sourceType, sourceName, scpTarget, scpPassword) {
+async function (sourceType, sourceName, scpTarget, scpPassword) {
     var myFileName, myFileExt;
     if (sourceType.includes('file')) {
         const fileName = parseExpectedText(sourceName);
@@ -62,7 +62,7 @@ function (sourceType, sourceName, scpTarget, scpPassword) {
             sourceFullPath = fs_session.getTestFileFullPath(myFileName, myFileExt);
             break;
         case 'downloaded file':
-            sourceFullPath = fs_session.checkDownloadFile(myFileName, myFileExt);
+            sourceFullPath = await fs_session.checkDownloadFile(myFileName, myFileExt);
             break;
         case 'folder':
             sourceFullPath = sourceName;
@@ -100,7 +100,7 @@ function (table) {
 
 When(/^(?::shell: )?I wait (?:(?:every (\d+) seconds for )?(\d+) minute(?:s)? )?on (?:the (first|last) (\d+) line(?:s)? of )?the "([^"]*)?" console to( not)* display the (text|regex) "(.*)?"$/,
 { timeout: 60 * 60 * 1000 },
-function (waitIntvSec, waitTimeoutMnt, firstOrLast, lineCount, consoleName, falseState, expectType, expectedText) {
+async function (waitIntvSec, waitTimeoutMnt, firstOrLast, lineCount, consoleName, falseState, expectType, expectedText) {
     // parse input
     const myConsoleName = parseExpectedText(consoleName);
     const myExpectedText = parseExpectedText(expectedText);
@@ -121,12 +121,12 @@ function (waitIntvSec, waitTimeoutMnt, firstOrLast, lineCount, consoleName, fals
     // wait and check loop
     do {
         // wait
-        browser.pause(myWaitIntvSec * 1000)
+        await browser.pause(myWaitIntvSec * 1000)
         // check
         // only keep 10k text
         const myReadIndex = ((Buffer.byteLength(myConsoleData[myConsoleName].stdout) - 10240) > 0) ? Buffer.byteLength(myConsoleData[myConsoleName].stdout) - 10240 : 0;
         const lineArray = stripAnsi.string(myConsoleData[myConsoleName].stdout.slice(myReadIndex)).split(/[\r\n]+/);
-        browser_session.displayMessage(browser, lineArray.join('\n'));
+        await browser_session.displayMessage(browser, lineArray.join('\n'));
         var lineText;
         switch (firstOrLast) {
             case 'first':
@@ -166,7 +166,7 @@ function (waitIntvSec, waitTimeoutMnt, firstOrLast, lineCount, consoleName, fals
 
 When(/^(?::shell: )?I (?:type|press) (?:the )?"(.*)" (key|string) (?:(\d+) time(?:s)? )?to the console "(.*)"(?: if the( first| last)? (\d+)(?:st|nd|rd|th)? line(?:s)? of the console does( not)* (contain|equal|match) the (text|regex) "(.*)?")?$/,
 { timeout: 60 * 1000 },
-function (inputContent, inputType, repeatTimes, consoleName, firstOrLast, lineCount, falseCase, compareAction, expectType, expectedText) {
+async function (inputContent, inputType, repeatTimes, consoleName, firstOrLast, lineCount, falseCase, compareAction, expectType, expectedText) {
     // parse input
     const myInputContent = parseExpectedText(inputContent);
     const myRepeatTimes = repeatTimes || 1;
@@ -199,7 +199,7 @@ function (inputContent, inputType, repeatTimes, consoleName, firstOrLast, lineCo
         // get consoleData object set up by previous step
         const myConsoleData = this.myConsoleData;
         const lineArray = stripAnsi.string(myConsoleData[myConsoleName].stdout).split(/[\r\n]+/);
-        browser_session.displayMessage(browser, lineArray.join('\n'));
+        await browser_session.displayMessage(browser, lineArray.join('\n'));
 
         var lineText;
         switch (myFirstOrLast.trim()) {

--- a/framework/step_files/vcenter/given.js
+++ b/framework/step_files/vcenter/given.js
@@ -5,29 +5,29 @@ const parseExpectedText = require(process.env.FrameworkPath + '/framework/step_f
 const { Given } = require('@cucumber/cucumber');
 
 Given(/^(?::vcenter: )?I have the "(.*)" command installed locally$/,
-  (cmdName) => {
+  async (cmdName) => {
     // check govc
     switch (cmdName) {
       case 'govc':
         var cmdString = `which ${cmdName}`;
         var resultString = cmdline_session.runCmd(cmdString);
         var resultObject = JSON.parse(resultString);
-        browser_session.displayMessage(browser, resultString);  
-        expect(resultObject.exitcode).toBe(0);    
+        await browser_session.displayMessage(browser, resultString);  
+        await expect(resultObject.exitcode).toBe(0);    
         break;
     }
   }
 );
 
 Given(/^(?::vcenter: )?I have govc access to my vcenter with the URL "(.*)"$/,
-  (vCenterURL) => {
+  async (vCenterURL) => {
     const myVCenterURL = parseExpectedText(vCenterURL);
     // push myVCenterURL to be runtime global variable
     process.env.myVCenterURL = myVCenterURL;
     const cmdString = `govc about.cert -u="${myVCenterURL}" -k=true`;
     const resultString = cmdline_session.runCmd(cmdString);
-    browser_session.displayMessage(browser, resultString);
+    await browser_session.displayMessage(browser, resultString);
     const resultObject = JSON.parse(resultString);
-    expect(resultObject.exitcode).toBe(0);
+    await expect(resultObject.exitcode).toBe(0);
   }
 );

--- a/framework/step_files/vcenter/then.js
+++ b/framework/step_files/vcenter/then.js
@@ -5,7 +5,7 @@ const parseExpectedText = require(process.env.FrameworkPath + '/framework/step_f
 const { Then } = require('@cucumber/cucumber');
 
 Then(/^(?::vcenter: )?The VM "(.*)" (?:should|does)( not)* exist in esxi host "(.*)" inside esxi dc "(.*)" under path "(.*)"$/,
-  (vmName, falseCase, hostIP, dcName, dcPath) => {
+  async (vmName, falseCase, hostIP, dcName, dcPath) => {
     let boolFalseCase = !!falseCase;
     const myVmName = parseExpectedText(vmName);
     const myEsxiHost = parseExpectedText(hostIP);
@@ -16,21 +16,21 @@ Then(/^(?::vcenter: )?The VM "(.*)" (?:should|does)( not)* exist in esxi host "(
     const cmdString = `govc ls -u="${myVCenterURL}" -k=true -dc="${myDcName}" "${myDcPath}/${myClusterIP}/${myEsxiHost}/${myVmName}"`;
     console.log(cmdString);
     const resultString = cmdline_session.runCmd(cmdString);
-    browser_session.displayMessage(browser, resultString);
+    await browser_session.displayMessage(browser, resultString);
     const resultObject = JSON.parse(resultString);
     if (boolFalseCase) {
-      expect(resultObject.output).not.toContain(`${myDcPath}/${myClusterIP}/${myEsxiHost}/${myVmName}`);
-      expect(resultObject.exitcode).toBe(0);
+      await expect(resultObject.output).not.toContain(`${myDcPath}/${myClusterIP}/${myEsxiHost}/${myVmName}`);
+      await expect(resultObject.exitcode).toBe(0);
     }
     else {
-      expect(resultObject.output).toContain(`${myDcPath}/${myClusterIP}/${myEsxiHost}/${myVmName}`);
-      expect(resultObject.exitcode).toBe(0);
+      await expect(resultObject.output).toContain(`${myDcPath}/${myClusterIP}/${myEsxiHost}/${myVmName}`);
+      await expect(resultObject.exitcode).toBe(0);
     }
   }
 );
 
 Then(/^(?::vcenter: )?The VM "(.*)" information inside esxi dc "(.*)" (?:should|does)( not)* (contain|equal|match) the (text|regex) "(.*)?"$/,
-  (vmName, dcName, dcPath, falseCase, compareAction, expectType, expectedText) => {
+  async (vmName, dcName, dcPath, falseCase, compareAction, expectType, expectedText) => {
     const myVmName = parseExpectedText(vmName);
     const myDcName = parseExpectedText(dcName);
     const myExpectedText = parseExpectedText(expectedText);
@@ -38,61 +38,61 @@ Then(/^(?::vcenter: )?The VM "(.*)" information inside esxi dc "(.*)" (?:should|
     const cmdString = `govc vm.info -u="${myVCenterURL}" -k=true -dc="${myDcName}" "${myVmName}"`;
     console.log(cmdString);
     const resultString = cmdline_session.runCmd(cmdString);
-    browser_session.displayMessage(browser, resultString);
+    await browser_session.displayMessage(browser, resultString);
     const resultObject = JSON.parse(resultString);
     var lineText = resultObject.output;
     let boolFalseCase = !!falseCase;
     if (boolFalseCase) {
       switch (compareAction) {
         case 'contain':
-          expect(lineText).not.toContain(
+          await expect(lineText).not.toContain(
             myExpectedText,
             `console should not contain the ${expectType} ` +
             `"${myExpectedText}"`
           );        
           break;
         case 'equal':
-          expect(lineText).not.toEqual(
+          await expect(lineText).not.toEqual(
             myExpectedText,
             `console should not equal the ${expectType} ` +
             `"${myExpectedText}"`
           );        
           break;
         case 'match':
-            expect(lineText.toLowerCase()).not.toMatch(
+            await expect(lineText.toLowerCase()).not.toMatch(
               RegExp(myExpectedText.toLowerCase()),
               `console should match the ${expectType} ` +
               `"${myExpectedText}"`
             );        
           break;
         default:
-          expect(false).toBe(true, `compareAction ${compareAction} should be one of contain, equal or match`);
+          await expect(false).toBe(true, `compareAction ${compareAction} should be one of contain, equal or match`);
       }
     } else {
       switch (compareAction) {
           case 'contain':
-            expect(lineText).toContain(
+            await expect(lineText).toContain(
               myExpectedText,
               `console should contain the ${expectType} ` +
               `"${myExpectedText}"`
             );        
             break;
         case 'equal':
-            expect(lineText).toEqual(
+            await expect(lineText).toEqual(
               myExpectedText,
               `console should equal the ${expectType} ` +
               `"${myExpectedText}"`
             );        
             break;
           case 'match':
-            expect(lineText.toLowerCase()).toMatch(
+            await expect(lineText.toLowerCase()).toMatch(
               RegExp(myExpectedText.toLowerCase()),
               `console should match the ${expectType} ` +
               `"${myExpectedText}"`
             );        
             break;
           default:
-            expect(false).toBe(true, `compareAction ${compareAction} should be one of contain, equal or match`);
+            await expect(false).toBe(true, `compareAction ${compareAction} should be one of contain, equal or match`);
       }
     }
   }

--- a/framework/step_files/vcenter/when.js
+++ b/framework/step_files/vcenter/when.js
@@ -9,7 +9,7 @@ const { When } = require('@cucumber/cucumber');
 
 When(/^(?::vcenter: )?I change the VM with config below:$/,
   { timeout: 15 * 60 * 1000 },
-  (table) => {
+  async (table) => {
     // process config table
     const config = table.rowsHash();
     const myVmName = parseExpectedText(config.vmName);
@@ -35,19 +35,19 @@ When(/^(?::vcenter: )?I change the VM with config below:$/,
     const cmdString = `govc vm.change -cpu-hot-add-enabled -memory-hot-add-enabled -latency=high ${parmCpuCount} ${parmMemSize} ${parmMemLimit} ${parmMemReservation} ${parmMemShares} ${parmVCenterURL} -k=true ${parmDcName} ${parmVmName}`;
     console.log(cmdString);
     const resultString = cmdline_session.runCmd(cmdString);
-    browser_session.displayMessage(browser, resultString);
+    await browser_session.displayMessage(browser, resultString);
     const exitCode = JSON.parse(resultString).exitcode;
     if (exitCode == 0) {
       console.log('change memory size action succeed.');
     } else {
       console.log('change memory size action failed. maybe power-off fist?');
     }
-    expect(exitCode).toBe(0);
+    await expect(exitCode).toBe(0);
   }
 );
 
 When(/^(?::vcenter: )?I connect the "(.*)" to "(.*)" for the VM "(.*)" inside esxi dc "(.*)"$/,
-  (nicName, netName, vmName, dcName) => {
+  async (nicName, netName, vmName, dcName) => {
     const myNicName = parseExpectedText(nicName);
     const myNetName = parseExpectedText(netName);
     const myVmName = parseExpectedText(vmName);
@@ -57,7 +57,7 @@ When(/^(?::vcenter: )?I connect the "(.*)" to "(.*)" for the VM "(.*)" inside es
     const cmdString = `govc ${govcCmd} -u="${myVCenterURL}" -k=true -dc="${myDcName}" -vm="${myVmName}" -net "${myNetName}" "${myNicName}"`;
     console.log(cmdString);
     const resultString = cmdline_session.runCmd(cmdString);
-    browser_session.displayMessage(browser, resultString);
+    await browser_session.displayMessage(browser, resultString);
     const exitCode = JSON.parse(resultString).exitcode;
     if (exitCode == 0) {
       console.log('network changed');
@@ -69,7 +69,7 @@ When(/^(?::vcenter: )?I connect the "(.*)" to "(.*)" for the VM "(.*)" inside es
 
 When(/^(?::vcenter: )?I (power on|power off|destroy) the VM "(.*)" inside esxi dc "(.*)" path "(.*)" esxi host "(.*)"$/,
   { timeout: 15 * 60 * 1000 },
-  (esxiCmd, vmName, dcName, dcPath, esxiHost) => {
+  async (esxiCmd, vmName, dcName, dcPath, esxiHost) => {
     const myVmName = parseExpectedText(vmName);
     const myDcName = parseExpectedText(dcName);
     const myDcPath = parseExpectedText(dcPath) || 'host';
@@ -90,11 +90,11 @@ When(/^(?::vcenter: )?I (power on|power off|destroy) the VM "(.*)" inside esxi d
     const cmdString = `govc ${govcCmd} -u="${myVCenterURL}" -k=true -dc="${myDcName}" "/${myDcName}/${myDcPath}/${myEsxiHost}/${myEsxiHost}/${myVmName}"`;
     console.log(cmdString);
     const resultString = cmdline_session.runCmd(cmdString);
-    browser_session.displayMessage(browser, resultString);
+    await browser_session.displayMessage(browser, resultString);
     const exitCode = JSON.parse(resultString).exitcode;
     if (exitCode == 0) {
       console.log('action accepted, waiting 90 seconds...');
-      browser.pause(9000);
+      await browser.pause(9000);
     } else {
       console.log('action not needed');
     }
@@ -103,7 +103,7 @@ When(/^(?::vcenter: )?I (power on|power off|destroy) the VM "(.*)" inside esxi d
 
 When(/^(?::vcenter: )?I (?:(re-))?open the HTML5 console to the VM "(.*)" inside esxi dc "(.*)"$/,
   { timeout: 15 * 60 * 1000 },
-  (reopen, vmName, dcName) => {
+  async (reopen, vmName, dcName) => {
     const myVmName = parseExpectedText(vmName);
     const myDcName = parseExpectedText(dcName);
     const myReopen = reopen || false;
@@ -119,27 +119,27 @@ When(/^(?::vcenter: )?I (?:(re-))?open the HTML5 console to the VM "(.*)" inside
     console.log(`updated console url: ${myConsoleUrl}`);
     // re-login if re-open
     if (myReopen) {
-      vcenter_session.reLoginVcenter(browser, myVCenterURL);
+      await vcenter_session.reLoginVcenter(browser, myVCenterURL);
     } else {
-      vcenter_session.loginVcenter(browser, myVCenterURL);
+      await vcenter_session.loginVcenter(browser, myVCenterURL);
     }
     // open VM console
     try {
-      browser.url(myConsoleUrl);
+      await browser.url(myConsoleUrl);
     } catch(e) {
-      vcenter_session.reLoginVcenter(browser, myVCenterURL);
-      browser.url(myConsoleUrl);
+      await vcenter_session.reLoginVcenter(browser, myVCenterURL);
+      await browser.url(myConsoleUrl);
     }
-    browser.pause(3000);
+    await browser.pause(3000);
     var consoleScreenText = JSON.parse(screen_session.screenFindImage('Screen-60'))[0].text;
     let loopCount = 3;
     // take a peek and re-login if the console is disconnected
-    while (loopCount > 0 && (browser.$('a=Back to login screen').isExisting() || consoleScreenText.length == 0 || consoleScreenText.join(' ').includes('The console has been disconnected'))) {
+    while (loopCount > 0 && (await (await browser.$('a=Back to login screen')).isExisting() || consoleScreenText.length == 0 || consoleScreenText.join(' ').includes('The console has been disconnected'))) {
       loopCount--;
       // open vSphere HTML5 ui, logout and re-login, in order to get a new session
-      vcenter_session.reLoginVcenter(browser, myVCenterURL);
-      browser.url(myConsoleUrl);
-      browser.pause(3000);
+      await vcenter_session.reLoginVcenter(browser, myVCenterURL);
+      await browser.url(myConsoleUrl);
+      await browser.pause(3000);
       consoleScreenText = JSON.parse(screen_session.screenFindImage('Screen-60'))[0].text;
     }
   }
@@ -174,7 +174,7 @@ When(/^(?::vcenter: )?I (?:(re-))?open the SSH console to the VM "(.*)" inside e
 
 When(/^(?::vcenter: )?I use the OVA URL to deploy an VM with config below:$/,
   { timeout: 60 * 60 * 1000 },
-  (table) => {
+  async (table) => {
     const config = table.rowsHash();
     const myDcName = parseExpectedText(config.dcName);
     const myDcPath = parseExpectedText(config.dcPath) || 'host';
@@ -191,10 +191,10 @@ When(/^(?::vcenter: )?I use the OVA URL to deploy an VM with config below:$/,
     console.log(cmdString);
     const resultString = cmdline_session.runCmd(cmdString);
     try {
-      browser_session.displayMessage(browser, resultString);
+      await browser_session.displayMessage(browser, resultString);
     } catch(e) {
       /* no-op */
     }
-    expect(JSON.parse(resultString).exitcode).toBe(0);
+    await expect(JSON.parse(resultString).exitcode).toBe(0);
   }
 );

--- a/framework/step_functions/action/announceMessage.js
+++ b/framework/step_functions/action/announceMessage.js
@@ -1,12 +1,12 @@
 const browser_session = require('../../libs/browser_session');
 const parseExpectedText = require('../common/parseExpectedText');
 
-module.exports = (target, message) => {
+module.exports = async (target, message) => {
     const myMessage = parseExpectedText(message);
     if (target) {
         switch (target) {
             case 'browser':
-                browser_session.displayMessage(browser, myMessage);
+                await browser_session.displayMessage(browser, myMessage);
                 break;
         }    
     }

--- a/framework/step_functions/action/assignValueOfElementInsideParentElementAs.js
+++ b/framework/step_functions/action/assignValueOfElementInsideParentElementAs.js
@@ -9,8 +9,8 @@
  * @param  {String}  ifExists           if exists
  */
 const parseExpectedText = require('../common/parseExpectedText');
-module.exports = (type, targetElementIndex, targetElement, parentElementIndex, parentElement, varName, ifExists) => {
-    const assignAction = () => {
+module.exports = async (type, targetElementIndex, targetElement, parentElementIndex, parentElement, varName, ifExists) => {
+    const assignAction = async () => {
         const myTargetElement = parseExpectedText(targetElement);
         const myParentElement = parseExpectedText(parentElement);
         const targetElementIndexInt = (targetElementIndex) ? parseInt(targetElementIndex) - 1 : 0;
@@ -19,22 +19,24 @@ module.exports = (type, targetElementIndex, targetElement, parentElementIndex, p
         const getWhat = (type == 'value') ? 'getValue' : 'getText';
         var retrivedValue;
         if (parentElement) {
-            $(myParentElement).waitForExist();
-            retrivedValue = $$(myParentElement)[parentElementIndexInt].$$(myTargetElement)[targetElementIndexInt][getWhat]();
+            await (await $(myParentElement)).waitForExist();
+            const parentElementList = await $$(myParentElement);
+            const targetElementList = await parentElementList[parentElementIndexInt].$$(myTargetElement);
+            retrivedValue = await targetElementList[targetElementIndexInt][getWhat]();
         } else {
-            retrivedValue = $$(myTargetElement)[targetElementIndexInt][getWhat]();
+            retrivedValue = await (await $$(myTargetElement))[targetElementIndexInt][getWhat]();
         }
         process.env[varName] = (type == 'number') ? retrivedValue.match(/\d+/)[0] : retrivedValue;
         console.log(`assigned "${process.env[varName]}" to ENV:${varName}`);    
     }
     if (ifExists) {
         try {
-            assignAction();
+            await assignAction();
         } catch (e) {
             console.log(`try: element ${targetElement} does not exist`);
         }
     } else {
-        assignAction();
+        await assignAction();
     }
 
 };

--- a/framework/step_functions/action/browserAction.js
+++ b/framework/step_functions/action/browserAction.js
@@ -2,12 +2,12 @@
  * Simple browser action
  * @param  {String}   command name of browser action without parameter, i.e. back, forward, reload, 
  */
-module.exports = (command) => {
+module.exports = async (command) => {
     try {
         if (command == 'reload') {
-            browser.reloadSession();
+            await browser.reloadSession();
         } else {
-            browser[command]();
+            await browser[command]();
         }    
     } catch (e) {
         console.log(`browser ${command} failed`);

--- a/framework/step_functions/action/bypassChromeSafetyWarning.js
+++ b/framework/step_functions/action/bypassChromeSafetyWarning.js
@@ -1,10 +1,10 @@
-module.exports = (wait, ifPresent) =>{
-    if (wait) try {browser.$('button=Advanced').waitForDisplayed(3000)} catch (e) {/*no-op*/};
+module.exports = async (wait, ifPresent) =>{
+    if (wait) try {await (await browser.$('button=Advanced')).waitForDisplayed(3000)} catch (e) {/*no-op*/};
     if (!ifPresent) {
-      expect(browser.$('button=Advanced').isExisting()).toBe(true);
+      await expect(await (await browser.$('button=Advanced')).isExisting()).toBe(true);
     } 
-    if (browser.$('button=Advanced').isDisplayed() || browser.$('button=Back to safety').isDisplayed()) {
-        browser.$('button=Advanced').click();
-        browser.$('#proceed-link').click();
+    if (await (await browser.$('button=Advanced')).isDisplayed() || await (await browser.$('button=Back to safety')).isDisplayed()) {
+        await (await browser.$('button=Advanced')).click();
+        await (await browser.$('#proceed-link')).click();
     }
 }

--- a/framework/step_functions/action/changeBrowserBackground.js
+++ b/framework/step_functions/action/changeBrowserBackground.js
@@ -2,10 +2,10 @@
  * set brower background colorName
  * @param  {String}   colorName set brower background colorName, i.e., red, white, blue, or color code, i.e., #ffffff, #0e0e0e
  */
-module.exports = (colorName) => {
+module.exports = async (colorName) => {
     const changeBrowserBackground = function(argument) { document.body.style.background = argument; };
     try {
-        browser.execute(changeBrowserBackground, colorName); 
+        await browser.execute(changeBrowserBackground, colorName); 
     } catch (e) {
         console.log(`changeBrowserBackground ${colorName} failed`);
     }

--- a/framework/step_functions/action/changeBrowserZoom.js
+++ b/framework/step_functions/action/changeBrowserZoom.js
@@ -2,10 +2,10 @@
  * browser zoom with percent
  * @param  {String}   percent zoom percent, i.e., 80%, 120%, 
  */
-module.exports = (percent) => {
+module.exports = async (percent) => {
     const changeBrowserZoom = function(argument) { document.body.style.zoom = argument; };
     try {
-        browser.execute(changeBrowserZoom, percent); 
+        await browser.execute(changeBrowserZoom, percent); 
     } catch (e) {
         console.log(`browser zoom ${percent} failed`);
     }

--- a/framework/step_functions/action/clearInputField.js
+++ b/framework/step_functions/action/clearInputField.js
@@ -3,8 +3,8 @@
  * @param  {String}   element Element selector
  */
 const parseExpectedText = require('../common/parseExpectedText');
-module.exports = (element) => {
+module.exports = async (element) => {
     const parsedElement = parseExpectedText(element);
-    browser.$(parsedElement).scrollIntoView();
-    browser.$(parsedElement).clearValue();
+    await (await browser.$(parsedElement)).scrollIntoView();
+    await (await browser.$(parsedElement)).clearValue();
 };

--- a/framework/step_functions/action/clickElementInsideParentElement.js
+++ b/framework/step_functions/action/clickElementInsideParentElement.js
@@ -10,7 +10,7 @@
  */
 
 const parseExpectedText = require('../common/parseExpectedText');
-module.exports = (action, targetElementIndex, targetElement, parentElementIndex, parentElement, containsTheText, ifExists) => {
+module.exports = async (action, targetElementIndex, targetElement, parentElementIndex, parentElement, containsTheText, ifExists) => {
     const myTargetElement = parseExpectedText(targetElement);
     const myParentElement = parseExpectedText(parentElement);
     const myContainsTheText = parseExpectedText(containsTheText) || '';
@@ -18,53 +18,58 @@ module.exports = (action, targetElementIndex, targetElement, parentElementIndex,
     const parentElementIndexInt = (parentElementIndex) ? parseInt(parentElementIndex) - 1 : 0;
     const deepClick = function(argument) { $(argument).click() };
 
-    const clickAction = () => {
+    const clickAction = async () => {
         var targetElementIdElement;
         if (parentElement) {
-            $(myParentElement).waitForExist();
-            const myFilteredParentElement = $$(myParentElement).filter(elem => elem.getText().includes(myContainsTheText));
+            await (await $(myParentElement)).waitForExist();
+            const myParentElementList = await $$(myParentElement);
+            const myFilteredParentElement = [];
+            for (const elem of myParentElementList) {
+                if ((await elem.getText()).includes(myContainsTheText)) {
+                    myFilteredParentElement.push(elem);
+                }
+            }
             const targetParentElement = (parentElementIndex == 'last') ? myFilteredParentElement.slice(-1) : myFilteredParentElement[parentElementIndexInt];
-            targetElementIdElement = (targetElementIndex == 'last') ? targetParentElement.$$(myTargetElement).slice(-1) : targetParentElement.$$(myTargetElement)[targetElementIndexInt];
+            targetElementIdElement = (targetElementIndex == 'last') ? (await targetParentElement.$$(myTargetElement)).slice(-1) : (await targetParentElement.$$(myTargetElement))[targetElementIndexInt];
         } else {
-            targetElementIdElement = (targetElementIndex == 'last') ? $$(myTargetElement).slice(-1) : $$(myTargetElement)[targetElementIndexInt];
+            targetElementIdElement = (targetElementIndex == 'last') ? (await $$(myTargetElement)).slice(-1) : (await $$(myTargetElement))[targetElementIndexInt];
         }
         // console.log(myTargetElement);
     
         switch (action) {
             case 'moveTo':
-                browser.$(targetElementIdElement).moveTo();
+                await (await browser.$(targetElementIdElement)).moveTo();
                 break;
             case 'clear':
-                browser.$(targetElementIdElement).clearValue();
+                await (await browser.$(targetElementIdElement)).clearValue();
                 break;
             case 'tryClick':
                 try {
                     console.log('1st try with direct click ...')
-                    browser.$(targetElementIdElement).click();
+                    await (await browser.$(targetElementIdElement)).click();
                 } catch (e) {
                     console.log('2nd try with deep click ...')
-                    browser.execute(deepClick, targetElementIdElement);          
+                    await browser.execute(deepClick, targetElementIdElement);          
                 }
                 break;
             case 'deepClick':
                     console.log('do deep click ...')
-                    browser.execute(deepClick, targetElementIdElement);          
+                    await browser.execute(deepClick, targetElementIdElement);          
                     break;
             case 'click':
             default:
-                browser.$(targetElementIdElement).click();
+                await (await browser.$(targetElementIdElement)).click();
                 break;
         }    
     }
 
     if (ifExists) {
         try {
-            clickAction();
+            await clickAction();
         } catch (e) {
             console.log(`try: element ${targetElement} does not exist`);
         }
     } else {
-        clickAction();
+        await clickAction();
     }
 };
-

--- a/framework/step_functions/action/clickToCondition.js
+++ b/framework/step_functions/action/clickToCondition.js
@@ -6,7 +6,7 @@
  * @param  {String}  falseCase     fasle case
  * @param  {String}  state         checked element state
  */
-module.exports = (clickElement, clickCount, checkElement, falseCase, state) => {
+module.exports = async (clickElement, clickCount, checkElement, falseCase, state) => {
     var myClickCount = clickCount || 2;
     var myState = state || 'existing';
     // convert conditions
@@ -16,10 +16,10 @@ module.exports = (clickElement, clickCount, checkElement, falseCase, state) => {
     if (checkAction == 'isChecked') checkAction = 'isSelected';
     var keepGoing = true;
     do {
-      browser.$(clickElement).click();
+      await (await browser.$(clickElement)).click();
       myClickCount--;
-      browser.pause(300);
-      keepGoing = !browser.$(checkElement)[checkAction]();
+      await browser.pause(300);
+      keepGoing = !(await (await browser.$(checkElement))[checkAction]());
       if (falseCase) keepGoing = !keepGoing;
     } while (myClickCount > 0 && keepGoing);
 };

--- a/framework/step_functions/action/closeAllButFirstTab.js
+++ b/framework/step_functions/action/closeAllButFirstTab.js
@@ -3,20 +3,21 @@
  * @param  {String}   obsolete Type of object to close (window or tab)
  */
 /* eslint-disable no-unused-vars */
-module.exports = (obsolete) => {
+module.exports = async (obsolete) => {
 /* eslint-enable no-unused-vars */
     /**
      * Get all the window handles
      * @type {Object}
      */
-    const windowHandles = browser.getWindowHandles();
+    const windowHandles = await browser.getWindowHandles();
 
     // Close all tabs but the first one
     windowHandles.reverse();
-    windowHandles.forEach((handle, index) => {
-        browser.switchToWindow(handle);
+    for (let index = 0; index < windowHandles.length; index++) {
+        const handle = windowHandles[index];
+        await browser.switchToWindow(handle);
         if (index < windowHandles.length - 1) {
-            browser.closeWindow();
+            await browser.closeWindow();
         }
-    });
+    }
 };

--- a/framework/step_functions/action/deleteCookie.js
+++ b/framework/step_functions/action/deleteCookie.js
@@ -2,6 +2,6 @@
  * Delete a cookie
  * @param  {String}   name The name of the cookie to delete
  */
-module.exports = (name) => {
-    browser.deleteCookies(name);
+module.exports = async (name) => {
+    await browser.deleteCookies(name);
 };

--- a/framework/step_functions/action/dragElement.js
+++ b/framework/step_functions/action/dragElement.js
@@ -3,6 +3,6 @@
  * @param  {String}   source      The selector for the source element
  * @param  {String}   destination The selector for the destination element
  */
-module.exports = (source, destination) => {
-    browser.$(source).dragAndDrop($(destination));
+module.exports = async (source, destination) => {
+    await (await browser.$(source)).dragAndDrop(await $(destination));
 };

--- a/framework/step_functions/action/handleModal.js
+++ b/framework/step_functions/action/handleModal.js
@@ -6,7 +6,7 @@ const browserAction = require("./browserAction");
  * @param  {String}   modalType Type of modal (alertbox, confirmbox, prompt)
  */
 const screen_session = require('../../libs/screen_session');
-module.exports = (action, modalType) => {
+module.exports = async (action, modalType) => {
     /**
      * The command to perform on the browser object
      * @type {String}
@@ -25,6 +25,6 @@ module.exports = (action, modalType) => {
         screen_session.keyTap();
     }
     else {
-        browserAction(command);
+        await browserAction(command);
     }
 };

--- a/framework/step_functions/action/moveToElement.js
+++ b/framework/step_functions/action/moveToElement.js
@@ -4,7 +4,7 @@
  * @param  {String}   x        X coordinate to move to
  * @param  {String}   y        Y coordinate to move to
  */
-module.exports = (element, x, y) => {
+module.exports = async (element, x, y) => {
     /**
      * X coordinate
      * @type {Int}
@@ -17,5 +17,5 @@ module.exports = (element, x, y) => {
      */
     const intY = parseInt(y, 10) || undefined;
 
-    browser.$(element).moveTo(intX, intY);
+    await (await browser.$(element)).moveTo(intX, intY);
 };

--- a/framework/step_functions/action/openTarget.js
+++ b/framework/step_functions/action/openTarget.js
@@ -7,7 +7,7 @@ const globSync = require("glob").sync;
 const getDownloadDir = require('../common/getDownloadDir');
 const parseExpectedText = require('../common/parseExpectedText');
 
-module.exports = (targetType, targetName) => {
+module.exports = async (targetType, targetName) => {
     /**
      * The expected text to validate against
      * @type {String}
@@ -21,28 +21,27 @@ module.exports = (targetType, targetName) => {
             fileTarget = getDownloadDir() + parsedTargetName.replace(/ /g, '\\ ');
             urlTarget = encodeURI('file://' + globSync(fileTarget)[0]); // we take the first match
             console.log(urlTarget);
-            browser.url(urlTarget);
+            await browser.url(urlTarget);
             break;
         case "file":
             fileTarget = parsedTargetName.replace(/^~\//, process.env.HOME + '/').replace(/ /g, '\ ');
             urlTarget = encodeURI('file://' + globSync(fileTarget)[0]); // we take the first match
             console.log(urlTarget);
-            browser.url(urlTarget);
+            await browser.url(urlTarget);
             break;
         case "path":
             urlTarget = encodeURI(browser.options.baseUrl + parsedTargetName);
             console.log(urlTarget);
-            browser.url(urlTarget);
+            await browser.url(urlTarget);
             break;
         case "url":
         default:
             urlTarget = encodeURI(parsedTargetName);
             try {
                 console.log(urlTarget);
-                browser.url(urlTarget);
+                await browser.url(urlTarget);
             } catch (e) {
                 console.log(e.message);
             }
         }
 };
-

--- a/framework/step_functions/action/pause.js
+++ b/framework/step_functions/action/pause.js
@@ -2,12 +2,12 @@
  * Pause execution for a given number of milliseconds
  * @param  {String}   ms   Number of milliseconds to pause
  */
-module.exports = (ms) => {
+module.exports = async (ms) => {
     /**
      * Number of milliseconds
      * @type {Int}
      */
     const intMs = parseInt(ms, 10);
 
-    browser.pause(intMs);
+    await browser.pause(intMs);
 };

--- a/framework/step_functions/action/resizeScreenSize.js
+++ b/framework/step_functions/action/resizeScreenSize.js
@@ -3,6 +3,6 @@
  * @param  {String}   screenWidth  The width of the window to resize to
  * @param  {String}   screenHeight The height of the window to resize to
  */
-module.exports = (screenWidth, screenHeight) => {
-    browser.setWindowSize(parseInt(screenWidth, 10), parseInt(screenHeight, 10));
+module.exports = async (screenWidth, screenHeight) => {
+    await browser.setWindowSize(parseInt(screenWidth, 10), parseInt(screenHeight, 10));
 };

--- a/framework/step_functions/action/scroll.js
+++ b/framework/step_functions/action/scroll.js
@@ -5,11 +5,11 @@
 
 const parseExpectedText = require('../common/parseExpectedText');
 
-module.exports = (selector) => {
+module.exports = async (selector) => {
     /**
      * The expected text to validate against
      * @type {String}
      */
     var parsedSelector = parseExpectedText(selector);
-    browser.$(parsedSelector).scrollIntoView();
+    await (await browser.$(parsedSelector)).scrollIntoView();
 };

--- a/framework/step_functions/action/selectFileFromDownloadFolder.js
+++ b/framework/step_functions/action/selectFileFromDownloadFolder.js
@@ -5,7 +5,7 @@
 const globSync = require("glob").sync;
 const getDownloadDir = require('../common/getDownloadDir');
 const screen_session = require('../../libs/screen_session');
-module.exports = (fileName) => {
+module.exports = async (fileName) => {
     const fileName_extSplit = fileName.split('.');
     const myFileExt = fileName_extSplit.length > 1 ? fileName_extSplit.pop() : null;
     const myFileName = fileName_extSplit.join('.');
@@ -13,7 +13,7 @@ module.exports = (fileName) => {
     if (myFilePath) {
         console.log(myFilePath);
         screen_session.typeString(myFilePath);
-        browser.pause(1000);
+        await browser.pause(1000);
     } else {
         console.log(`${myFilePath} not found`)
     }

--- a/framework/step_functions/action/selectOption.js
+++ b/framework/step_functions/action/selectOption.js
@@ -5,7 +5,7 @@
  * @param  {String}   selectionValue Value to select by
  * @param  {String}   selectElem     Element selector
  */
-module.exports = (selectionType, selectionValue, selectElem) => {
+module.exports = async (selectionType, selectionValue, selectElem) => {
     /**
      * The method to use for selecting the option
      * @type {String}
@@ -38,5 +38,5 @@ module.exports = (selectionType, selectionValue, selectElem) => {
         }
     }
 
-    browser.$(selectElem)[command](arg1, arg2);
+    await (await browser.$(selectElem))[command](arg1, arg2);
 };

--- a/framework/step_functions/action/selectOptionByIndex.js
+++ b/framework/step_functions/action/selectOptionByIndex.js
@@ -6,12 +6,12 @@
  *
  * @todo  merge with selectOption
  */
-module.exports = (index, obsolete, selectElem) => {
+module.exports = async (index, obsolete, selectElem) => {
     /**
      * The index of the option to select
      * @type {Int}
      */
     const optionIndex = parseInt(index, 10);
 
-    browser.$(selectElem).selectByIndex(optionIndex);
+    await (await browser.$(selectElem)).selectByIndex(optionIndex);
 };

--- a/framework/step_functions/action/setCookie.js
+++ b/framework/step_functions/action/setCookie.js
@@ -4,8 +4,8 @@
  * @param  {String}   cookieName    The name of the cookie
  * @param  {String}   cookieContent The value of the cookie
  */
-module.exports = (cookieName, cookieContent) => {
-    browser.setCookies({
+module.exports = async (cookieName, cookieContent) => {
+    await browser.setCookies({
         name: cookieName,
         value: cookieContent,
     });

--- a/framework/step_functions/action/setInputFieldWithEnvVars.js
+++ b/framework/step_functions/action/setInputFieldWithEnvVars.js
@@ -13,7 +13,7 @@
  */
 const checkIfElementExists = require('../check/checkIfElementExists');
 const parseExpectedText = require('../common/parseExpectedText');
-module.exports = (method, isEnvVar, value, targetElementIndex, fieldType, targetElement, parentElementIndex, parentElement, containsTheText) => {
+module.exports = async (method, isEnvVar, value, targetElementIndex, fieldType, targetElement, parentElementIndex, parentElement, containsTheText) => {
     /**
      * The command to perform on the browser object (addValue or setValue)
      * @type {String}
@@ -28,15 +28,21 @@ module.exports = (method, isEnvVar, value, targetElementIndex, fieldType, target
     
     var targetElementIdElement;
     if (parentElement) {
-        $(myParentElement).waitForExist();
-        const myFilteredParentElement = $$(myParentElement).filter(elem => elem.getText().includes(myContainsTheText));
+        await (await $(myParentElement)).waitForExist();
+        const myParentElementList = await $$(myParentElement);
+        const myFilteredParentElement = [];
+        for (const elem of myParentElementList) {
+            if ((await elem.getText()).includes(myContainsTheText)) {
+                myFilteredParentElement.push(elem);
+            }
+        }
         const targetParentElement = (parentElementIndex == 'last') ? myFilteredParentElement.slice(-1) : myFilteredParentElement[parentElementIndexInt];
-        targetElementIdElement = (targetElementIndex == 'last') ? targetParentElement.$$(myTargetElement).slice(-1) : targetParentElement.$$(myTargetElement)[targetElementIndexInt];
+        targetElementIdElement = (targetElementIndex == 'last') ? (await targetParentElement.$$(myTargetElement)).slice(-1) : (await targetParentElement.$$(myTargetElement))[targetElementIndexInt];
     } else {
-        targetElementIdElement = (targetElementIndex == 'last') ? $$(myTargetElement).slice(-1) : $$(myTargetElement)[targetElementIndexInt];
+        targetElementIdElement = (targetElementIndex == 'last') ? (await $$(myTargetElement)).slice(-1) : (await $$(myTargetElement))[targetElementIndexInt];
     }
 
-    const currentValue = (fieldType == 'inputfield') ? targetElementIdElement.getValue() : targetElementIdElement.getText()
+    const currentValue = (fieldType == 'inputfield') ? await targetElementIdElement.getValue() : await targetElementIdElement.getText()
     if (command == 'addValue') inputValue = currentValue + inputValue;
-    targetElementIdElement.setValue(inputValue);
+    await targetElementIdElement.setValue(inputValue);
 };

--- a/framework/step_functions/action/switchIframe.js
+++ b/framework/step_functions/action/switchIframe.js
@@ -4,7 +4,7 @@
  * @param  {String}   name       The name of the iframe 
  */
 const parseExpectedText = require('../common/parseExpectedText');
-module.exports = (index, name) => {
+module.exports = async (index, name) => {
     /**
      * The index of the option to select
      * @type {Int}
@@ -19,12 +19,12 @@ module.exports = (index, name) => {
     }
 
     if (index && index == 'parent') {
-        browser.switchToParentFrame();
+        await browser.switchToParentFrame();
     } else if (index && index == 'last') {
-        iFrameIndex = $$(iFrameElement).length -1;
+        iFrameIndex = (await $$(iFrameElement)).length -1;
     } else {
         iFrameIndex = (index) ? parseInt(index, 10) - 1 : 0;
-        $(iFrameElement).waitForExist();
-        browser.switchToFrame($$(iFrameElement)[iFrameIndex]);
+        await (await $(iFrameElement)).waitForExist();
+        await browser.switchToFrame((await $$(iFrameElement))[iFrameIndex]);
     }
 };

--- a/framework/step_functions/action/switchToOrCloseOpenedWindow.js
+++ b/framework/step_functions/action/switchToOrCloseOpenedWindow.js
@@ -3,14 +3,14 @@
  * @param  {String}   action switch to or close
  * @param  {String}   index  The index of the tab
  */
-module.exports = (action, index) => {
+module.exports = async (action, index) => {
     if (index && index == 'last') {
-        const lastWindowHandle = browser.getWindowHandles().slice(-1)[0];
-        browser.switchToWindow(lastWindowHandle);
+        const lastWindowHandle = (await browser.getWindowHandles()).slice(-1)[0];
+        await browser.switchToWindow(lastWindowHandle);
     } else {
         const optionIndex = parseInt(index, 10) - 1;
-        const windowHandle = browser.getWindowHandles()[optionIndex];
-        browser.switchToWindow(windowHandle);
+        const windowHandle = (await browser.getWindowHandles())[optionIndex];
+        await browser.switchToWindow(windowHandle);
     }
-    if (action == 'close') browser.closeWindow();
+    if (action == 'close') await browser.closeWindow();
 };

--- a/framework/step_functions/action/waitAndActOnElement.js
+++ b/framework/step_functions/action/waitAndActOnElement.js
@@ -10,7 +10,7 @@ const waitForCondition = require('../action/waitForCondition');
  * @param  {String}   element           Element selector
  * @param  {String}   ifExists          if exists
  */
-module.exports = (waitMs, action, type, element, ifExists) => {
+module.exports = async (waitMs, action, type, element, ifExists) => {
     const myWaitMS = parseInt(waitMs, 10) || 3000;
     /**
      * Element to perform the action on
@@ -59,29 +59,29 @@ module.exports = (waitMs, action, type, element, ifExists) => {
             method = action;
     }
 
-    const actionBlock = () => {
-        waitFor(targetElement);
+    const actionBlock = async () => {
+        await waitFor(targetElement);
         if (method.toLowerCase().includes('click')) {
-            waitForCondition(targetElement, myWaitMS, null, 'clickable');
+            await waitForCondition(targetElement, myWaitMS, null, 'clickable');
         }
-        browser.$(targetElement).scrollIntoView();
-        checkCondition('some', targetElement, 'becomes', null, 'visible');
+        await (await browser.$(targetElement)).scrollIntoView();
+        await checkCondition('some', targetElement, 'becomes', null, 'visible');
         if (action == 'double click') {
             // use wdio's native doubleClick; the old jQuery $(el).dblclick()
             // required the page to load jQuery and threw '$ is not defined'
-            browser.$(targetElement).doubleClick();
+            await (await browser.$(targetElement)).doubleClick();
         } else {
-            browser.$(targetElement)[method](options);
+            await (await browser.$(targetElement))[method](options);
         }    
     }
     
     if (ifExists) {
         try {
-            actionBlock();
+            await actionBlock();
         } catch (e) {
             console.log(`try: element ${targetElement} does not exist`);
         }
     } else {
-        actionBlock();
+        await actionBlock();
     }
 };

--- a/framework/step_functions/action/waitFor.js
+++ b/framework/step_functions/action/waitFor.js
@@ -7,11 +7,12 @@
  * @param  {String}   state                    State to check for (default
  *                                             existence)
  */
-const waitForContent = (element, ms, getWhat, falseCase) => {
+const waitForContent = async (element, ms, getWhat, falseCase) => {
     try {
         // getText, getValue 
-        return browser.waitUntil(
-            () => ($(element)[getWhat]().length > 0) == !falseCase,
+        const myElement = await $(element);
+        return await browser.waitUntil(
+            async () => ((await myElement[getWhat]()).length > 0) == !falseCase,
             {
                 timeout: ms,
                 timeoutMsg: `wait for ${getWhat} timeout`
@@ -21,12 +22,13 @@ const waitForContent = (element, ms, getWhat, falseCase) => {
         return false;
     }
 }
-const waitForCondition = (element, ms, isWhat, falseCase, element2) => {
+const waitForCondition = async (element, ms, isWhat, falseCase, element2) => {
     // isClickable, isDisplayed, isDisplayedInViewPort, isEnabled, isExisting, isFocused, isSelected,
     // isEqual(with element2)
     try {
-        return browser.waitUntil(
-            () => ($(element)[isWhat](element2)) == !falseCase,
+        const myElement = await $(element);
+        return await browser.waitUntil(
+            async () => (await myElement[isWhat](element2)) == !falseCase,
             {
                 timeout: ms,
                 timeoutMsg: `wait for ${isWhat} timeout`
@@ -40,7 +42,7 @@ const waitForCondition = (element, ms, isWhat, falseCase, element2) => {
 const parseExpectedText = require('../common/parseExpectedText');
 
 module.exports =
-(elem, ms, falseCase, state) => {
+async (elem, ms, falseCase, state) => {
     /**
      * Parsed element selector
      * @type {String}
@@ -70,10 +72,10 @@ module.exports =
         var parsedState = myState.replace('be ', '');
         parsedState = parsedState.charAt(0).toUpperCase() + parsedState.slice(1);
         const command = `waitFor${parsedState}`;
-        browser.$(myElem)[command](intMs, !!falseCase);
+        await (await browser.$(myElem))[command](intMs, !!falseCase);
     } else if (['getText', 'getValue'].includes(myState)) {
-        waitForContent(myElem, intMs, myState, !!falseCase);
+        await waitForContent(myElem, intMs, myState, !!falseCase);
     } else {
-        waitForCondition(myElem, intMs, myState, !!falseCase);
+        await waitForCondition(myElem, intMs, myState, !!falseCase);
     }
 };

--- a/framework/step_functions/action/waitForCondition.js
+++ b/framework/step_functions/action/waitForCondition.js
@@ -7,11 +7,12 @@
  * @param  {String}   state                    State to check for (default
  *                                             existence)
  */
-const waitForContent = (element, ms, getWhat, falseCase) => {
+const waitForContent = async (element, ms, getWhat, falseCase) => {
     try {
-        return browser.waitUntil(
+        const myElement = await $(element);
+        return await browser.waitUntil(
             // getText, getValue
-            () => { return $(element)[getWhat]().length > 0 == !falseCase },
+            async () => { return (await myElement[getWhat]()).length > 0 == !falseCase },
             {
                 timeout: ms,
                 timeoutMsg: `$(${element}).${getWhat}().length > 0 == ${!falseCase} timeout`
@@ -22,12 +23,13 @@ const waitForContent = (element, ms, getWhat, falseCase) => {
     }
 }
 
-const waitForCondition = (element, ms, isWhat, falseCase, element2) => {
+const waitForCondition = async (element, ms, isWhat, falseCase, element2) => {
     // isClickable, isDisplayed, isDisplayedInViewPort, isEnabled, isExisting, isFocused, isSelected,
     // isEqual(with element2)
     try {
-        return browser.waitUntil(
-            () => { return $(element)[isWhat](element2) == !falseCase },
+        const myElement = await $(element);
+        return await browser.waitUntil(
+            async () => { return (await myElement[isWhat](element2)) == !falseCase },
             {
                 timeout: ms,
                 timeoutMsg: `$(${element}).${isWhat}(${element2}) == ${!falseCase} timeout`
@@ -41,7 +43,7 @@ const waitForCondition = (element, ms, isWhat, falseCase, element2) => {
 const parseExpectedText = require('../common/parseExpectedText');
 
 module.exports =
-(elem, ms, falseCase, state) => {
+async (elem, ms, falseCase, state) => {
     /**
      * Parsed element selector
      * @type {String}
@@ -62,7 +64,7 @@ module.exports =
 
     try {
         const existOption = {timeout: intMs, reverse: !!falseCase};
-        $(myElem).waitForExist(existOption);
+        await (await $(myElem)).waitForExist(existOption);
     } catch(e) {/*no-op*/}
 
     if (['existing', 'enabled', 'displayed', 'clickable'].includes(myState)) {
@@ -74,17 +76,17 @@ module.exports =
             reverse: !!falseCase,
             timeoutMsg: `${myElem}.$waitFor${myState} == ${!falseCase} timeout`
         }
-        if ($(myElem).isExisting()) $(myElem)[waitForCommand](option);
+        if (await (await $(myElem)).isExisting()) await (await $(myElem))[waitForCommand](option);
     } else if (myState.includes('containing')) { // 'containing a text', 'containing a value'
         if (myState.includes('value')) myState = 'getValue';
         if (myState.includes('text')) myState = 'getText';
-        if ($(myElem).isExisting()) waitForContent(myElem, intMs, myState, !!falseCase);
+        if (await (await $(myElem)).isExisting()) await waitForContent(myElem, intMs, myState, !!falseCase);
     } else {
         // convert conditions
         var checkAction = `is${myState.charAt(0).toUpperCase()}${myState.slice(1)}`;
         // "is visible" = CSS-visible (isDisplayed), not in-viewport
         if (checkAction == 'isVisible') checkAction = 'isDisplayed';
         if (checkAction == 'isChecked') checkAction = 'isSelected';
-        if ($(myElem).isExisting()) waitForCondition(myElem, intMs, checkAction, !!falseCase);
+        if (await (await $(myElem)).isExisting()) await waitForCondition(myElem, intMs, checkAction, !!falseCase);
     }
 };

--- a/framework/step_functions/action/waitForDownload.js
+++ b/framework/step_functions/action/waitForDownload.js
@@ -7,7 +7,7 @@
  */
 const globSync = require("glob").sync;
 const getDownloadDir = require('../common/getDownloadDir');
-module.exports = (targetName, ms, falseState) => {
+module.exports = async (targetName, ms, falseState) => {
     let fileTarget = getDownloadDir() + targetName.replace(/ /g, '\\ ');
     /**
      * Maximum number of milliseconds to wait, default 3000
@@ -28,13 +28,13 @@ module.exports = (targetName, ms, falseState) => {
     }, intMs);
     if (boolFalseState) {
         while (globSync(fileTarget)[0] && !timeOut) {
-            browser.pause(3000);
+            await browser.pause(3000);
         }
     } else {
         while (!globSync(fileTarget)[0] && !timeOut) {
-            browser.pause(3000);
+            await browser.pause(3000);
         }
     }
     clearInterval(handle);
-    browser.pause(2000);
+    await browser.pause(2000);
 };

--- a/framework/step_functions/action/waitOnElementInsideParentElementToBeConditon.js
+++ b/framework/step_functions/action/waitOnElementInsideParentElementToBeConditon.js
@@ -12,7 +12,7 @@
 const parseExpectedText = require('../common/parseExpectedText');
 const waitForCondition = require('./waitForCondition');
 
-module.exports = (targetElementIndex, targetElement, parentElementIndex, parentElement, ms, falseCase, state) => {
+module.exports = async (targetElementIndex, targetElement, parentElementIndex, parentElement, ms, falseCase, state) => {
     const myTargetElement = parseExpectedText(targetElement);
     const myParentElement = parseExpectedText(parentElement);
     const targetElementIndexInt = (targetElementIndex) ? parseInt(targetElementIndex) - 1 : 0;
@@ -22,29 +22,30 @@ module.exports = (targetElementIndex, targetElement, parentElementIndex, parentE
 
     var targetElementIdElement;
     if (myParentElement) {
-        $(myParentElement).waitForExist();
+        await (await $(myParentElement)).waitForExist();
+        const parentElementList = await $$(myParentElement);
         if (parentElementIndexInt >= 0) {
-            $$(myParentElement)[parentElementIndexInt].$(myTargetElement).waitForExist(existOption);
+            const parentElementInstance = parentElementList[parentElementIndexInt];
+            await (await parentElementInstance.$(myTargetElement)).waitForExist(existOption);
             try {
-                targetElementIdElement = $$(myParentElement)[parentElementIndexInt].$$(myTargetElement)[targetElementIndexInt];
+                targetElementIdElement = (await parentElementInstance.$$(myTargetElement))[targetElementIndexInt];
             } catch(e) { /* no-op */ }
-            if (targetElementIdElement) waitForCondition(targetElementIdElement, intMs, !!falseCase, state);
+            if (targetElementIdElement) await waitForCondition(targetElementIdElement, intMs, !!falseCase, state);
         } else {
-            $$(myParentElement).forEach((pElement, pIndex) => {
-                $$(pElement.selector)[pIndex].$(myTargetElement).waitForExist(existOption);
+            for (const [pIndex, pElement] of parentElementList.entries()) {
+                await (await (await $$(pElement.selector))[pIndex].$(myTargetElement)).waitForExist(existOption);
                 try {
-                    targetElementIdElement = $$(pElement.selector)[pIndex].$$(myTargetElement)[targetElementIndexInt];
+                    targetElementIdElement = (await (await $$(pElement.selector))[pIndex].$$(myTargetElement))[targetElementIndexInt];
                 } catch(e) { /* no-op */ }
-                if (targetElementIdElement) waitForCondition(targetElementIdElement, intMs, !!falseCase, state);    
-            });
+                if (targetElementIdElement) await waitForCondition(targetElementIdElement, intMs, !!falseCase, state);    
+            }
         }
     } else {
         try {
-            $(myTargetElement).waitForExist(existOption);
+            await (await $(myTargetElement)).waitForExist(existOption);
         } catch(e) { /* no-op */ }
-        targetElementIdElement = $$(myTargetElement)[targetElementIndexInt];
-        if (targetElementIdElement) waitForCondition(targetElementIdElement, intMs, !!falseCase, state);
+        targetElementIdElement = (await $$(myTargetElement))[targetElementIndexInt];
+        if (targetElementIdElement) await waitForCondition(targetElementIdElement, intMs, !!falseCase, state);
     }
-    browser.pause(500);
+    await browser.pause(500);
 };
-

--- a/framework/step_functions/check/checkClass.js
+++ b/framework/step_functions/check/checkClass.js
@@ -8,7 +8,7 @@
 
 const parseExpectedText = require('../common/parseExpectedText');
 
-module.exports = (element, falseCase, expectedClassName) => {
+module.exports = async (element, falseCase, expectedClassName) => {
     /**
      * The expected text to validate against
      * @type {String}
@@ -27,15 +27,15 @@ module.exports = (element, falseCase, expectedClassName) => {
      */
     // getAttribute('class') is null when the element has no class attribute at all;
     // treat that as "no classes" so 'does not have' assertions pass.
-    const classesList = browser.$(parsedElement).getAttribute('class') || '';
+    const classesList = (await (await browser.$(parsedElement)).getAttribute('class')) || '';
 
     if (falseCase === 'does not have') {
-        expect(classesList).not.toContain(
+        await expect(classesList).not.toContain(
                 parsedExpectedClassName,
                 `Element ${parsedElement} should not have the class ${parsedExpectedClassName}`
             );
     } else {
-        expect(classesList).toContain(
+        await expect(classesList).toContain(
                 parsedExpectedClassName,
                 `Element ${parsedElement} should have the class ${parsedExpectedClassName}`
             );

--- a/framework/step_functions/check/checkCondition.js
+++ b/framework/step_functions/check/checkCondition.js
@@ -7,7 +7,7 @@
  * @param  {String}   state        checked element state
  */
 const parseExpectedText = require('../common/parseExpectedText');
-module.exports = (partOf, element, verb, falseCase, state) => {
+module.exports = async (partOf, element, verb, falseCase, state) => {
     const myElem = parseExpectedText(element);
     const myPartOf = partOf || 'some';
     var checkAction = `is${state.charAt(0).toUpperCase()}${state.slice(1)}`;
@@ -18,17 +18,17 @@ module.exports = (partOf, element, verb, falseCase, state) => {
     if (checkAction == 'isChecked') checkAction = 'isSelected';
     var myResult;
     if (verb.includes('become')) {
-        if (browser.$(myElem)[checkAction]() == !!falseCase) {
+        if ((await (await browser.$(myElem))[checkAction]()) == !!falseCase) {
             var waitAction = `waitFor${state.charAt(0).toUpperCase()}${state.slice(1)}`;
             if (waitAction == 'waitForVisible') waitAction = 'waitForDisplayed';
             if (waitAction == 'waitForChecked') waitAction = 'waitForClickable';
             if (waitAction == 'waitForSelected') waitAction = 'waitForSelected';
             if (waitAction == 'waitForExisting') waitAction = 'waitForExist';        
             const waitOption = {timeout: 5000, reverse: !!falseCase};
-            browser.$(myElem)[waitAction](waitOption);
+            await (await browser.$(myElem))[waitAction](waitOption);
         }
     }
-    myResult = browser.$(myElem)[checkAction]();
+    myResult = await (await browser.$(myElem))[checkAction]();
     if (typeof(myResult) == 'object') {
         switch (myPartOf) {
             default:
@@ -41,5 +41,5 @@ module.exports = (partOf, element, verb, falseCase, state) => {
         }
     }
 
-    expect(myResult).toBe(!falseCase, `Expected ${myPartOf} of element "${myElem}" ${verb}${falseCase} ${state} but failed`);
+    await expect(myResult).toBe(!falseCase, `Expected ${myPartOf} of element "${myElem}" ${verb}${falseCase} ${state} but failed`);
 };

--- a/framework/step_functions/check/checkContainsAnyTextOrValue.js
+++ b/framework/step_functions/check/checkContainsAnyTextOrValue.js
@@ -8,7 +8,7 @@
 
 const parseExpectedText = require('../common/parseExpectedText');
 
-module.exports = (element, falseCase, type) => {
+module.exports = async (element, falseCase, type) => {
     /**
      * The expected text to validate against
      * @type {String}
@@ -16,14 +16,14 @@ module.exports = (element, falseCase, type) => {
     var parsedElement = parseExpectedText(element);
     var retrivedValue;
     if (type == 'value') {
-        retrivedValue = browser.$(parsedElement).getValue();
+        retrivedValue = await (await browser.$(parsedElement)).getValue();
     } else {
-        retrivedValue = browser.$(parsedElement).getText();
+        retrivedValue = await (await browser.$(parsedElement)).getText();
     }
 
     if (!!falseCase) {
-        expect(retrivedValue).toEqual('');
+        await expect(retrivedValue).toEqual('');
     } else {
-        expect(retrivedValue).not.toEqual('');
+        await expect(retrivedValue).not.toEqual('');
     }
 };

--- a/framework/step_functions/check/checkContainsEqualsMatchesTextOrValue.js
+++ b/framework/step_functions/check/checkContainsEqualsMatchesTextOrValue.js
@@ -10,7 +10,7 @@
 
 const parseExpectedText = require('../common/parseExpectedText');
 
-module.exports = (element, falseCase, action, type, expectedText) => {
+module.exports = async (element, falseCase, action, type, expectedText) => {
     /**
      * The expected text to validate against
      * @type {String}
@@ -51,14 +51,14 @@ module.exports = (element, falseCase, action, type, expectedText) => {
         boolFalseCase = true;
     }
 
-    const retrivedValue = browser.$(parsedElement)[command]().toString();
+    const retrivedValue = (await (await browser.$(parsedElement))[command]()).toString();
     // console.log(`${type} : ${retrivedValue}`)
 
     if (boolFalseCase) {
         switch (action) {
             case 'contain':
             case 'contains':
-                expect(retrivedValue).not.toContain(
+                await expect(retrivedValue).not.toContain(
                     myExpectedText,
                     `element "${parsedElement}" should not contain ${type} ` +
                     `"${myExpectedText}"`
@@ -66,7 +66,7 @@ module.exports = (element, falseCase, action, type, expectedText) => {
                 break;
             case 'equal':
             case 'equals':
-                expect(retrivedValue).not.toEqual(
+                await expect(retrivedValue).not.toEqual(
                     myExpectedText,
                     `element "${parsedElement}" should not equal ${type} ` +
                     `"${myExpectedText}"`
@@ -74,20 +74,20 @@ module.exports = (element, falseCase, action, type, expectedText) => {
                 break;
             case 'match':
             case 'matches':
-                expect(retrivedValue).not.toMatch(
+                await expect(retrivedValue).not.toMatch(
                     RegExp(myExpectedText),
                     `element "${parsedElement}" should not match ${type} ` +
                     `"${myExpectedText}"`
                 );        
                 break;
             default:
-                expect(false).toBe(true, `action ${action} should be one of contains, equals or matches`);
+                await expect(false).toBe(true, `action ${action} should be one of contains, equals or matches`);
         }
     } else {
         switch (action) {
             case 'contain':
             case 'contains':
-                expect(retrivedValue).toContain(
+                await expect(retrivedValue).toContain(
                     myExpectedText,
                     `element "${parsedElement}" should contain ${type} ` +
                     `"${myExpectedText}"`
@@ -95,7 +95,7 @@ module.exports = (element, falseCase, action, type, expectedText) => {
                 break;
             case 'equal':
             case 'equals':
-                expect(retrivedValue).toEqual(
+                await expect(retrivedValue).toEqual(
                     myExpectedText,
                     `element "${parsedElement}" should equal ${type} ` +
                     `"${myExpectedText}"`
@@ -103,14 +103,14 @@ module.exports = (element, falseCase, action, type, expectedText) => {
                 break;
             case 'match':
             case 'matches':
-                expect(retrivedValue).toMatch(
+                await expect(retrivedValue).toMatch(
                     RegExp(myExpectedText),
                     `element "${parsedElement}" should match ${type} ` +
                     `"${myExpectedText}"`
                 );        
                 break;
             default:
-                expect(false).toBe(true, `action ${action} should be one of contains, equals or matches`);
+                await expect(false).toBe(true, `action ${action} should be one of contains, equals or matches`);
         }
     }
 }

--- a/framework/step_functions/check/checkContainsText.js
+++ b/framework/step_functions/check/checkContainsText.js
@@ -9,7 +9,7 @@
 
 const parseExpectedText = require('../common/parseExpectedText');
 
-module.exports = (elementType, element, falseCase, expectedText) => {
+module.exports = async (elementType, element, falseCase, expectedText) => {
     /**
      * The expected text to validate against
      * @type {String}
@@ -29,8 +29,8 @@ module.exports = (elementType, element, falseCase, expectedText) => {
     let command = 'getText';
 
     if (
-        browser.$(parsedElement).getText() == '' &&
-        browser.$(parsedElement).getAttribute('value') !== null
+        (await (await browser.$(parsedElement)).getText()) == '' &&
+        (await (await browser.$(parsedElement)).getAttribute('value')) !== null
     ) {
         command = 'getValue';
     }
@@ -45,7 +45,7 @@ module.exports = (elementType, element, falseCase, expectedText) => {
      * The text of the element
      * @type {String}
      */
-    const text = browser.$(parsedElement)[command]();
+    const text = await (await browser.$(parsedElement))[command]();
 
     if (typeof expectedText === 'undefined') {
         myExpectedText = falseCase;
@@ -55,8 +55,8 @@ module.exports = (elementType, element, falseCase, expectedText) => {
     }
 
     if (boolFalseCase) {
-        expect(text).not.toContain(myExpectedText);
+        await expect(text).not.toContain(myExpectedText);
     } else {
-        expect(text).toContain(myExpectedText);
+        await expect(text).toContain(myExpectedText);
     }
 };

--- a/framework/step_functions/check/checkCookieContent.js
+++ b/framework/step_functions/check/checkCookieContent.js
@@ -8,7 +8,7 @@
 
 const parseExpectedText = require('../common/parseExpectedText');
 
-module.exports = (cookieName, falseCase, expectedValue) => {
+module.exports = async (cookieName, falseCase, expectedValue) => {
     /**
      * The expected text to validate against
      * @type {String}
@@ -25,20 +25,20 @@ module.exports = (cookieName, falseCase, expectedValue) => {
      * The cookie retrieved from the browser object
      * @type {Object}
      */
-    const cookie = browser.getCookies([parsedCookieName])[0];
+    const cookie = (await browser.getCookies([parsedCookieName]))[0];
 
-    expect(cookie.name).toEqual(
+    await expect(cookie.name).toEqual(
         parsedCookieName,
         `no cookie found with the name "${parsedCookieName}"`
     );
 
     if (falseCase) {
-        expect(cookie.value).not.toEqual(
+        await expect(cookie.value).not.toEqual(
                 parsedExpectedValue,
                 `expected cookie "${parsedCookieName}" not to have value "${parsedExpectedValue}"`
             );
     } else {
-        expect(cookie.value).toEqual(
+        await expect(cookie.value).toEqual(
                 parsedExpectedValue,
                 `expected cookie "${parsedCookieName}" to have value "${parsedExpectedValue}"` +
                 ` but got "${cookie.value}"`

--- a/framework/step_functions/check/checkCookieExists.js
+++ b/framework/step_functions/check/checkCookieExists.js
@@ -7,7 +7,7 @@
 
 const parseExpectedText = require('../common/parseExpectedText');
 
-module.exports = (cookieName, falseCase) => {
+module.exports = async (cookieName, falseCase) => {
     /**
      * The expected text to validate against
      * @type {String}
@@ -18,15 +18,15 @@ module.exports = (cookieName, falseCase) => {
      * The cookie as retrieved from the browser
      * @type {Object}
      */
-    const cookie = browser.getCookies([parsedCookieName])[0];
+    const cookie = (await browser.getCookies([parsedCookieName]))[0];
 
     if (falseCase) {
-        expect(typeof(cookie)).toEqual(
+        await expect(typeof(cookie)).toEqual(
             'undefined',
             `Expected cookie "${parsedCookieName}" not to exists but it does`
         );
     } else {
-        expect(typeof(cookie)).not.toEqual(
+        await expect(typeof(cookie)).not.toEqual(
             'undefined',
             `Expected cookie "${parsedCookieName}" to exists but it does not`
         );

--- a/framework/step_functions/check/checkDimension.js
+++ b/framework/step_functions/check/checkDimension.js
@@ -9,7 +9,7 @@
 
 const parseExpectedText = require('../common/parseExpectedText');
 
-module.exports = (element, falseCase, expectedSize, dimension) => {
+module.exports = async (element, falseCase, expectedSize, dimension) => {
     /**
      * The expected text to validate against
      * @type {String}
@@ -26,7 +26,7 @@ module.exports = (element, falseCase, expectedSize, dimension) => {
      * The size of the given element
      * @type {Object}
      */
-    const elementSize = browser.$(parsedElement).getSize();
+    const elementSize = await (await browser.$(parsedElement)).getSize();
 
     /**
      * Parsed size to check for
@@ -52,13 +52,13 @@ module.exports = (element, falseCase, expectedSize, dimension) => {
     }
 
     if (falseCase) {
-        expect(originalSize).not.toEqual(
+        await expect(originalSize).not.toEqual(
                 intExpectedSize,
                 `Element "${parsedElement}" should not have a ${label} of ` +
                 `${intExpectedSize}px`
             );
     } else {
-        expect(originalSize).toEqual(
+        await expect(originalSize).toEqual(
                 intExpectedSize,
                 `Element "${parsedElement}" should have a ${label} of ` +
                 `${intExpectedSize}px, but is ${originalSize}px`

--- a/framework/step_functions/check/checkDownloadedFileContainsEqualsMatchesText.js
+++ b/framework/step_functions/check/checkDownloadedFileContainsEqualsMatchesText.js
@@ -14,7 +14,7 @@ const parseExpectedText = require('../common/parseExpectedText');
 const getDownloadDir = require('../common/getDownloadDir');
 const fs_session = require('../../libs/fs_session');
 
-module.exports = (fileName, rowNumber, colNumber, falseCase, action, expectedText) => {
+module.exports = async (fileName, rowNumber, colNumber, falseCase, action, expectedText) => {
     const myAction = (action) ? action.trim() : 'contains';
     const fileName_extSplit = fileName.split('.');
     const myFileExt = fileName_extSplit.length > 1 ? fileName_extSplit.pop() : null;
@@ -31,7 +31,7 @@ module.exports = (fileName, rowNumber, colNumber, falseCase, action, expectedTex
     switch (myFileExt) {
         case 'pdf':
         case 'PDF':
-            downloadFileContent = fs_session.readPdfData(myFilePath).text;
+            downloadFileContent = (await fs_session.readPdfData(myFilePath)).text;
             if (rowNumber) {
                 readTargetContent = downloadFileContent.split('\n')[rowNumber];
             } else {
@@ -84,53 +84,53 @@ module.exports = (fileName, rowNumber, colNumber, falseCase, action, expectedTex
         switch (myAction) {
             case 'contain':
             case 'contains':
-                expect(readTargetContent).not.toContain(
+                await expect(readTargetContent).not.toContain(
                     myExpectedText,
                     `file "${fileName}" should not contain text "${myExpectedText}"`
                 );        
                 break;
             case 'equal':
             case 'equals':
-                expect(readTargetContent).not.toEqual(
+                await expect(readTargetContent).not.toEqual(
                     myExpectedText,
                     `file "${fileName}" should not equal text "${myExpectedText}"`
                 );        
                 break;
             case 'match':
             case 'matches':
-                expect(readTargetContent).not.toMatch(
+                await expect(readTargetContent).not.toMatch(
                     RegExp(myExpectedText),
                     `file "${fileName}" should not match text "${myExpectedText}"`
                 );        
                 break;
             default:
-                expect(false).toBe(true, `action ${myAction} should be one of contains, equals or matches`);
+                await expect(false).toBe(true, `action ${myAction} should be one of contains, equals or matches`);
         }
     } else {
         switch (myAction) {
             case 'contain':
             case 'contains':
-                expect(readTargetContent).toContain(
+                await expect(readTargetContent).toContain(
                     myExpectedText,
                     `file "${fileName}" should contain text "${myExpectedText}"`
                 );        
                 break;
             case 'equal':
             case 'equals':
-                expect(readTargetContent).toEqual(
+                await expect(readTargetContent).toEqual(
                     myExpectedText,
                     `file "${fileName}" should equal text "${myExpectedText}"`
                 );        
                 break;
             case 'match':
             case 'matches':
-                expect(readTargetContent).toMatch(
+                await expect(readTargetContent).toMatch(
                     RegExp(myExpectedText),
                     `file "${fileName}" should match text "${myExpectedText}"`
                 );        
                 break;
             default:
-                expect(false).toBe(true, `action ${myAction} should be one of contains, equals or matches`);
+                await expect(false).toBe(true, `action ${myAction} should be one of contains, equals or matches`);
         }
     }
 }

--- a/framework/step_functions/check/checkDownloadedFileContainsNumOfLines.js
+++ b/framework/step_functions/check/checkDownloadedFileContainsNumOfLines.js
@@ -10,7 +10,7 @@ const getDownloadDir = require('../common/getDownloadDir');
 const fs_session = require('../../libs/fs_session');
 const parseExpectedText = require('../common/parseExpectedText');
 
-module.exports = (fileName, compareAction, expectedNumOfLines) => {
+module.exports = async (fileName, compareAction, expectedNumOfLines) => {
     const myCompareAction = (compareAction) ? compareAction.trim() : 'exactly';
     const myExpectedNumber = (expectedNumOfLines) ? parseInt(parseExpectedText(expectedNumOfLines)) : 0;
     const fileName_extSplit = fileName.split('.');
@@ -21,7 +21,7 @@ module.exports = (fileName, compareAction, expectedNumOfLines) => {
     switch (myFileExt) {
         case 'pdf':
         case 'PDF':
-            countedNumOfLines = fs_session.readPdfData(myFilePath).text.split('\n').length;
+            countedNumOfLines = (await fs_session.readPdfData(myFilePath)).text.split('\n').length;
             break;
         case 'xls':
         case 'XLS':
@@ -39,32 +39,32 @@ module.exports = (fileName, compareAction, expectedNumOfLines) => {
 
     switch (myCompareAction) {
         case 'more than':
-            expect(retrivedValue).toBeGreaterThan(
+            await expect(retrivedValue).toBeGreaterThan(
                 myExpectedNumber,
                 `file "${fileName}" should contain more than "${myExpectedNumber}" lines`
             );        
             break;
         case 'no more than':
-            expect(retrivedValue).not.toBeGreaterThan(
+            await expect(retrivedValue).not.toBeGreaterThan(
                 myExpectedNumber,
                 `file "${fileName}" should contain no more than "${myExpectedNumber}" lines`
             );        
             break;
         case 'less than':
-            expect(retrivedValue).toBeLessThan(
+            await expect(retrivedValue).toBeLessThan(
                 myExpectedNumber,
                 `file "${fileName}" should contain less than "${myExpectedNumber}" lines`
             );        
             break;
         case 'no less than':
-            expect(retrivedValue).not.toBeLessThan(
+            await expect(retrivedValue).not.toBeLessThan(
                 myExpectedNumber,
                 `file "${fileName}" should contain no less than "${myExpectedNumber}" lines`
             );        
             break;
         case 'exactly':
         default:
-            expect(retrivedValue).toBe(
+            await expect(retrivedValue).toBe(
                 myExpectedNumber,
                 `file "${fileName}" should contain exactly "${myExpectedNumber}" lines`
             );        

--- a/framework/step_functions/check/checkDownloadedFileContainsRowsAndColumns.js
+++ b/framework/step_functions/check/checkDownloadedFileContainsRowsAndColumns.js
@@ -12,7 +12,7 @@ const getDownloadDir = require('../common/getDownloadDir');
 const fs_session = require('../../libs/fs_session');
 const parseExpectedText = require('../common/parseExpectedText');
 
-module.exports = (fileName, rowCompareAction, expectedNumOfRows, rowType, colCompareAction, expectedNumOfColumns, columnType) => {
+module.exports = async (fileName, rowCompareAction, expectedNumOfRows, rowType, colCompareAction, expectedNumOfColumns, columnType) => {
     const myRowCompareAction = (rowCompareAction) ? rowCompareAction.trim() : 'exactly';
     const myColCompareAction = (colCompareAction) ? colCompareAction.trim() : 'exactly';
     const fileName_extSplit = fileName.split('.');
@@ -24,7 +24,7 @@ module.exports = (fileName, rowCompareAction, expectedNumOfRows, rowType, colCom
     switch (myFileExt) {
         case 'pdf':
         case 'PDF':
-            countedNumOfRows = fs_session.readPdfData(myFilePath).text.split('\n').length;
+            countedNumOfRows = (await fs_session.readPdfData(myFilePath)).text.split('\n').length;
             break;
         case 'xls':
         case 'XLS':
@@ -54,32 +54,32 @@ module.exports = (fileName, rowCompareAction, expectedNumOfRows, rowType, colCom
         const parsedExpectedNumOfRows = (expectedNumOfRows) ? parseInt(parseExpectedText(expectedNumOfRows)) : 0;
         switch (myRowCompareAction) {
             case 'more than':
-                expect(countedNumOfRows).toBeGreaterThan(
+                await expect(countedNumOfRows).toBeGreaterThan(
                     parsedExpectedNumOfRows,
                     `file ${fileName} should contain more than ${parsedExpectedNumOfRows} rows`
                 );    
                 break;
             case 'no more than':
-                expect(countedNumOfRows).not.toBeGreaterThan(
+                await expect(countedNumOfRows).not.toBeGreaterThan(
                     parsedExpectedNumOfRows,
                     `file ${fileName} should contain no more than ${parsedExpectedNumOfRows} rows`
                 );    
                 break;
             case 'less than':
-                expect(countedNumOfRows).toBeLessThan(
+                await expect(countedNumOfRows).toBeLessThan(
                     parsedExpectedNumOfRows,
                     `file ${fileName} should contain less than ${parsedExpectedNumOfRows} rows`
                 );
                 break;
             case 'no less than':
-                expect(countedNumOfRows).not.toBeLessThan(
+                await expect(countedNumOfRows).not.toBeLessThan(
                     parsedExpectedNumOfRows,
                     `file ${fileName} should contain no less than ${parsedExpectedNumOfRows} rows`
                 );
                 break;
             case 'exactly':
             default:
-                expect(countedNumOfRows).toBe(
+                await expect(countedNumOfRows).toBe(
                     parsedExpectedNumOfRows,
                     `file ${fileName} should contain ${parsedExpectedNumOfRows} rows`
                 );
@@ -91,31 +91,31 @@ module.exports = (fileName, rowCompareAction, expectedNumOfRows, rowType, colCom
         let parsedExpectedNumOfColumns = (expectedNumOfColumns) ? parseInt(parseExpectedText(expectedNumOfColumns)) : 0;
         switch (myColCompareAction) {
             case 'more than':
-                expect(countedNumOfColumns).toBeGreaterThan(
+                await expect(countedNumOfColumns).toBeGreaterThan(
                     parsedExpectedNumOfColumns,
                     `file ${fileName} should contain more than ${parsedExpectedNumOfColumns} columns`
                 );    
                 break;
             case 'no more than':
-                expect(countedNumOfColumns).not.toBeGreaterThan(
+                await expect(countedNumOfColumns).not.toBeGreaterThan(
                     parsedExpectedNumOfColumns,
                     `file ${fileName} should contain no more than ${parsedExpectedNumOfColumns} columns`
                 );    
                 break;    
             case 'less than':
-                expect(countedNumOfColumns).toBeLessThan(
+                await expect(countedNumOfColumns).toBeLessThan(
                     parsedExpectedNumOfColumns,
                     `file ${fileName} should contain less than ${parsedExpectedNumOfColumns} columns`
                 );
             case 'no less than':
-                expect(countedNumOfColumns).not.toBeLessThan(
+                await expect(countedNumOfColumns).not.toBeLessThan(
                     parsedExpectedNumOfColumns,
                     `file ${fileName} should contain no less than ${parsedExpectedNumOfColumns} columns`
                 );
                 break;
             case 'exactly':
             default:
-                expect(countedNumOfColumns).toBe(
+                await expect(countedNumOfColumns).toBe(
                     parsedExpectedNumOfColumns,
                     `file ${fileName} should contain ${parsedExpectedNumOfColumns} columns`
                 );

--- a/framework/step_functions/check/checkDownloadedJsonFileConformsTemplateFile.js
+++ b/framework/step_functions/check/checkDownloadedJsonFileConformsTemplateFile.js
@@ -9,7 +9,7 @@ const fs_session = require('../../libs/fs_session');
 const globSync = require("glob").sync;
 const getDownloadDir = require('../common/getDownloadDir');
 const parseExpectedText = require('../common/parseExpectedText');
-module.exports = (jsonFileName, templateFileName) => {
+module.exports = async (jsonFileName, templateFileName) => {
     const jsonFile_extSplit = jsonFileName.split('.');
     const jsonFileExt = jsonFile_extSplit.length > 1 ? jsonFile_extSplit.pop() : 'json';
     const myJsonFileName = jsonFile_extSplit.join('.');
@@ -27,8 +27,8 @@ module.exports = (jsonFileName, templateFileName) => {
     const ajv = new Ajv();
     const validate = ajv.compile(jsonSchema);
     const checkData = (jsonData.items) ? jsonData.items : jsonData; 
-    checkData.forEach(data => {
+    for (const data of checkData) {
         let valid = validate(data);
-        expect(valid).toBe(true, `Invalid data entry:\ndata:\n${JSON.stringify(data)}\nerror:\n${ajv.errorsText(validate.errors)}`);
-    })    
+        await expect(valid).toBe(true, `Invalid data entry:\ndata:\n${JSON.stringify(data)}\nerror:\n${ajv.errorsText(validate.errors)}`);
+    }    
 }

--- a/framework/step_functions/check/checkElementExists.js
+++ b/framework/step_functions/check/checkElementExists.js
@@ -6,7 +6,7 @@ const checkIfElementExists = require('../check/checkIfElementExists');
  *                               (an or no)
  * @param  {String}   elem       Element selector
  */
-module.exports = (isExisting, elem) => {
+module.exports = async (isExisting, elem) => {
     /**
      * Falsecase assertion
      * @type {Boolean}
@@ -17,5 +17,5 @@ module.exports = (isExisting, elem) => {
         falseCase = false;
     }
 
-    checkIfElementExists(elem, falseCase);
+    await checkIfElementExists(elem, falseCase);
 };

--- a/framework/step_functions/check/checkElementStatusInsideParentElement.js
+++ b/framework/step_functions/check/checkElementStatusInsideParentElement.js
@@ -9,7 +9,7 @@
  */
 
 const parseExpectedText = require('../common/parseExpectedText');
-module.exports = (targetElementIndex, targetElement, parentElementIndex, parentElement, falseCase, expectedStauts) => {
+module.exports = async (targetElementIndex, targetElement, parentElementIndex, parentElement, falseCase, expectedStauts) => {
     const myTargetElement = parseExpectedText(targetElement);
     const myParentElement = parseExpectedText(parentElement);
     const targetElementIndexInt = (targetElementIndex) ? parseInt(targetElementIndex) - 1 : 0;
@@ -17,10 +17,11 @@ module.exports = (targetElementIndex, targetElement, parentElementIndex, parentE
     
     var targetElementIdElement;
     if (parentElement) {
-        $(myParentElement).waitForExist();
-        targetElementIdElement = browser.$$(myParentElement)[parentElementIndexInt].$$(myTargetElement)[targetElementIndexInt];
+        await (await $(myParentElement)).waitForExist();
+        const myParentElements = await browser.$$(myParentElement);
+        targetElementIdElement = (await myParentElements[parentElementIndexInt].$$(myTargetElement))[targetElementIndexInt];
     } else {
-        targetElementIdElement = browser.$$(myTargetElement)[targetElementIndexInt];
+        targetElementIdElement = (await browser.$$(myTargetElement))[targetElementIndexInt];
     }
 
     /**
@@ -38,50 +39,50 @@ module.exports = (targetElementIndex, targetElement, parentElementIndex, parentE
     if (boolFalseCase) {
         switch (expectedStauts) {
             case 'displayed':
-                expect(targetElementIdElement.isDisplayed()).not.toBe(
+                await expect(await targetElementIdElement.isDisplayed()).not.toBe(
                     true,
                     `target element "${targetElement}" inside parent element "${parentElement}" should not be ${expectedStauts}`
                 );        
                 break;
             case 'enabled':
-                expect(targetElementIdElement.isEnabled()).not.toBe(
+                await expect(await targetElementIdElement.isEnabled()).not.toBe(
                     true,
                     `target element "${targetElement}" inside parent element "${parentElement}" should not be ${expectedStauts}`
                 );        
                 break;
             case 'checked':
             case 'selected':
-                expect(targetElementIdElement.isSelected()).not.toBe(
+                await expect(await targetElementIdElement.isSelected()).not.toBe(
                     true,
                     `target element "${targetElement}" inside parent element "${parentElement}" should not be ${expectedStauts}`
                 );        
                 break;
             default:
-                expect(false).toEqual(true, `expectedStauts ${expectedStauts} should be one of displayed, enabled or selected`);
+                await expect(false).toEqual(true, `expectedStauts ${expectedStauts} should be one of displayed, enabled or selected`);
         }
     } else {
         switch (expectedStauts) {
             case 'displayed':
-                expect(targetElementIdElement.isDisplayed()).toBe(
+                await expect(await targetElementIdElement.isDisplayed()).toBe(
                     true,
                     `target element "${targetElement}" inside parent element "${parentElement}" should be ${expectedStauts}`
                 );        
                 break;
             case 'enabled':
-                expect(targetElementIdElement.isEnabled()).toBe(
+                await expect(await targetElementIdElement.isEnabled()).toBe(
                     true,
                     `target element "${targetElement}" inside parent element "${parentElement}" should be ${expectedStauts}`
                 );        
                 break;
             case 'checked':
             case 'selected':
-                expect(targetElementIdElement.isSelected()).toBe(
+                await expect(await targetElementIdElement.isSelected()).toBe(
                     true,
                     `target element "${targetElement}" inside parent element "${parentElement}" should be ${expectedStauts}`
                 );        
                 break;
             default:
-                expect(false).toEqual(true, `expectedStauts ${expectedStauts} should be one of displayed, enabled or selected`);
+                await expect(false).toEqual(true, `expectedStauts ${expectedStauts} should be one of displayed, enabled or selected`);
         }
     }
 };

--- a/framework/step_functions/check/checkElementTextValueIsEmpty.js
+++ b/framework/step_functions/check/checkElementTextValueIsEmpty.js
@@ -1,8 +1,8 @@
 const checkContainsAnyTextOrValue = require('./checkContainsAnyTextOrValue');
 
-module.exports = (element, type, falseCase) => {
+module.exports = async (element, type, falseCase) => {
     // is Empty == undefined == not contain any TextOrValue
     // is not Empty == contains some TextOrValue
 
-    checkContainsAnyTextOrValue(element, !!!falseCase, type);
+    await checkContainsAnyTextOrValue(element, !!!falseCase, type);
 };

--- a/framework/step_functions/check/checkFontProperty.js
+++ b/framework/step_functions/check/checkFontProperty.js
@@ -8,7 +8,7 @@
  *                                  attribute matches or not
  * @param  {String}   expectedValue The value to match against
  */
-module.exports = (isCSS, attrName, elem, falseCase, expectedValue) => {
+module.exports = async (isCSS, attrName, elem, falseCase, expectedValue) => {
     /**
      * The command to use for fetching the expected value
      * @type {String}
@@ -25,7 +25,7 @@ module.exports = (isCSS, attrName, elem, falseCase, expectedValue) => {
      * The actual attribute value
      * @type {Mixed}
      */
-    let attributeValue = browser.$(elem)[command](attrName);
+    let attributeValue = await (await browser.$(elem))[command](attrName);
 
     /**
      * when getting something with a color or font-weight WebdriverIO returns a
@@ -36,13 +36,13 @@ module.exports = (isCSS, attrName, elem, falseCase, expectedValue) => {
     }
 
     if (falseCase) {
-        expect(attributeValue).not.toEqual(
+        await expect(attributeValue).not.toEqual(
                 expectedValue,
                 `${attrType}: ${attrName} of element "${elem}" should not contain ` +
                 `"${expectedValue}"`
             );
     } else {
-        expect(attributeValue).toEqual(
+        await expect(attributeValue).toEqual(
                 expectedValue,
                 `${attrType}: ${attrName} of element "${elem}" should contain ` +
                 `"${expectedValue}", but got "${attributeValue}"`

--- a/framework/step_functions/check/checkIfElementExists.js
+++ b/framework/step_functions/check/checkIfElementExists.js
@@ -5,21 +5,21 @@
  * @param  {String}  atLest    Check if the element exists atLest this number (as string)
  *                             of times
  */
-module.exports = (element, falseCase, atLest) => {
+module.exports = async (element, falseCase, atLest) => {
     const myAtLeast = atLest || 1;
     /**
      * The number of elements found in the DOM
      * @type {Int}
      */
-    const nrOfElements = browser.$$(element).length;
+    const nrOfElements = (await browser.$$(element)).length;
 
     if (falseCase === true) {
-        expect(nrOfElements).toBe(
+        await expect(nrOfElements).toBe(
             0,
             `Element with selector "${element}" should not exist on the page`
         );
     } else {
-        expect(nrOfElements).not.toBeLessThan(
+        await expect(nrOfElements).not.toBeLessThan(
             myAtLeast,
             `Element with selector "${element}" should exist on at least ${myAtLeast} times the page`
         );

--- a/framework/step_functions/check/checkIfElementExistsInsideParentElement.js
+++ b/framework/step_functions/check/checkIfElementExistsInsideParentElement.js
@@ -9,7 +9,7 @@
  */
 
 const parseExpectedText = require('../common/parseExpectedText');
-module.exports = (targetElement, parentElementIndex, parentElement, falseCase, compareAction, expectedNumber) => {
+module.exports = async (targetElement, parentElementIndex, parentElement, falseCase, compareAction, expectedNumber) => {
     const myTargetElement = parseExpectedText(targetElement);
     const myParentElement = parseExpectedText(parentElement);
     const parentElementIndexInt = (parentElementIndex) ? parseInt(parentElementIndex) - 1 : 0;
@@ -18,46 +18,47 @@ module.exports = (targetElement, parentElementIndex, parentElement, falseCase, c
 
     var appearanceNumber;
     if (parentElement) {
-        $(myParentElement).waitForExist();
-        appearanceNumber = browser.$$(myParentElement)[parentElementIndexInt].$$(myTargetElement).length;
+        await (await $(myParentElement)).waitForExist();
+        const myParentElements = await browser.$$(myParentElement);
+        appearanceNumber = (await myParentElements[parentElementIndexInt].$$(myTargetElement)).length;
     } else {
-        appearanceNumber = browser.$$(myTargetElement).length;
+        appearanceNumber = (await browser.$$(myTargetElement)).length;
     }
 
     if (!!falseCase) {
-        expect(myCompareAction).not.toContain('no', 'do not support double negative statement');
-        expect(myCompareAction).not.toContain('at least', 'do not support no at least statement');    
+        await expect(myCompareAction).not.toContain('no', 'do not support double negative statement');
+        await expect(myCompareAction).not.toContain('at least', 'do not support no at least statement');    
         switch (myCompareAction) {
             case 'exactly':
-                expect(appearanceNumber).not.toEqual(myExpectedNumber);
+                await expect(appearanceNumber).not.toEqual(myExpectedNumber);
                 break;
             case 'more than':
-                expect(appearanceNumber).not.toBeGreaterThan(myExpectedNumber);
+                await expect(appearanceNumber).not.toBeGreaterThan(myExpectedNumber);
                 break;
             case 'less than':
-                expect(appearanceNumber).not.toBeLessThan(myExpectedNumber);
+                await expect(appearanceNumber).not.toBeLessThan(myExpectedNumber);
                 break;
         }
     } else {
         switch (myCompareAction) {
             case 'exactly':
-                expect(appearanceNumber).toEqual(myExpectedNumber);
+                await expect(appearanceNumber).toEqual(myExpectedNumber);
                 break;
             case 'not exactly':
-                expect(appearanceNumber).not.toEqual(myExpectedNumber);
+                await expect(appearanceNumber).not.toEqual(myExpectedNumber);
                 break;
             case 'more than':
-                expect(appearanceNumber).toBeGreaterThan(myExpectedNumber);
+                await expect(appearanceNumber).toBeGreaterThan(myExpectedNumber);
                 break;
             case 'no more than':
-                expect(appearanceNumber).not.toBeGreaterThan(myExpectedNumber);
+                await expect(appearanceNumber).not.toBeGreaterThan(myExpectedNumber);
                 break;
             case 'less than':
-                expect(appearanceNumber).toBeLessThan(myExpectedNumber);
+                await expect(appearanceNumber).toBeLessThan(myExpectedNumber);
                 break;
             case 'at least':
             case 'no less than':
-                expect(appearanceNumber).not.toBeLessThan(myExpectedNumber);
+                await expect(appearanceNumber).not.toBeLessThan(myExpectedNumber);
                 break;
         }        
     }

--- a/framework/step_functions/check/checkIfElementInsideParentElementEqualsMatchesTextOrValue.js
+++ b/framework/step_functions/check/checkIfElementInsideParentElementEqualsMatchesTextOrValue.js
@@ -11,7 +11,7 @@
  */
 
 const parseExpectedText = require('../common/parseExpectedText');
-module.exports = (targetElementIndex, targetElement, parentElementIndex, parentElement, falseCase, action, targetType, expectedText) => {
+module.exports = async (targetElementIndex, targetElement, parentElementIndex, parentElement, falseCase, action, targetType, expectedText) => {
     const myTargetElement = parseExpectedText(targetElement);
     const myParentElement = parseExpectedText(parentElement);
     const targetElementIndexInt = (targetElementIndex) ? parseInt(targetElementIndex) - 1 : 0;
@@ -19,10 +19,11 @@ module.exports = (targetElementIndex, targetElement, parentElementIndex, parentE
     
     var targetElementIdElement;
     if (parentElement) {
-        $(myParentElement).waitForExist();
-        targetElementIdElement = browser.$$(myParentElement)[parentElementIndexInt].$$(myTargetElement)[targetElementIndexInt];
+        await (await $(myParentElement)).waitForExist();
+        const myParentElements = await browser.$$(myParentElement);
+        targetElementIdElement = (await myParentElements[parentElementIndexInt].$$(myTargetElement))[targetElementIndexInt];
     } else {
-        targetElementIdElement = browser.$$(myTargetElement)[targetElementIndexInt];
+        targetElementIdElement = (await browser.$$(myTargetElement))[targetElementIndexInt];
     }
 
     /**
@@ -51,15 +52,15 @@ module.exports = (targetElementIndex, targetElement, parentElementIndex, parentE
     var retrivedValue;
     switch (targetType) {
         case 'value':
-            if (targetElementIdElement.getTagName() == 'input') {
-                retrivedValue = targetElementIdElement.getValue();
+            if ((await targetElementIdElement.getTagName()) == 'input') {
+                retrivedValue = await targetElementIdElement.getValue();
             } else {
-                retrivedValue = browser.getElementAttribute(targetElementIdElement, targetType);
+                retrivedValue = await browser.getElementAttribute(targetElementIdElement, targetType);
             }
             break;
         case 'text':
         default:
-            retrivedValue = targetElementIdElement.getText();
+            retrivedValue = await targetElementIdElement.getText();
     }
 
     retrivedValue = retrivedValue.replace(/[^\x00-\x7F]/g, '');
@@ -68,7 +69,7 @@ module.exports = (targetElementIndex, targetElement, parentElementIndex, parentE
         switch (action) {
             case 'contain':
             case 'contains':
-                expect(retrivedValue).not.toContain(
+                await expect(retrivedValue).not.toContain(
                     myExpectedText,
                     `target element "${targetElement}" inside parent element "${parentElement}" should not contain ${targetType} ` +
                     `"${myExpectedText}"`
@@ -76,7 +77,7 @@ module.exports = (targetElementIndex, targetElement, parentElementIndex, parentE
                 break;
             case 'equal':
             case 'equals':
-                expect(retrivedValue).not.toEqual(
+                await expect(retrivedValue).not.toEqual(
                     myExpectedText,
                     `target element "${targetElement}" inside parent element "${parentElement}" should not equal ${targetType} ` +
                     `"${myExpectedText}"`
@@ -84,20 +85,20 @@ module.exports = (targetElementIndex, targetElement, parentElementIndex, parentE
                 break;
             case 'match':
             case 'matches':
-                expect(retrivedValue).not.toMatch(
+                await expect(retrivedValue).not.toMatch(
                     RegExp(myExpectedText),
                     `target element "${targetElement}" inside parent element "${parentElement}" should not match ${targetType} ` +
                     `"${myExpectedText}"`
                 );        
                 break;
             default:
-                expect(false).toEqual(true, `action ${action} should be one of contains, equals or matches`);
+                await expect(false).toEqual(true, `action ${action} should be one of contains, equals or matches`);
         }
     } else {
         switch (action) {
             case 'contain':
             case 'contains':
-                expect(retrivedValue).toContain(
+                await expect(retrivedValue).toContain(
                     myExpectedText,
                     `target element "${targetElement}" inside parent element "${parentElement}" should contain ${targetType} ` +
                     `"${myExpectedText}"`
@@ -105,7 +106,7 @@ module.exports = (targetElementIndex, targetElement, parentElementIndex, parentE
                 break;
             case 'equal':
             case 'equals':
-                expect(retrivedValue).toEqual(
+                await expect(retrivedValue).toEqual(
                     myExpectedText,
                     `target element "${targetElement}" inside parent element "${parentElement}" should equal ${targetType} ` +
                     `"${myExpectedText}"`
@@ -113,14 +114,14 @@ module.exports = (targetElementIndex, targetElement, parentElementIndex, parentE
                 break;
             case 'match':
             case 'matches':
-                expect(retrivedValue).toMatch(
+                await expect(retrivedValue).toMatch(
                     RegExp(myExpectedText),
                     `target element "${targetElement}" inside parent element "${parentElement}" should match ${targetType} ` +
                     `"${myExpectedText}"`
                 );        
                 break;
             default:
-                expect(false).toEqual(true, `action ${action} should be one of contains, equals or matches`);
+                await expect(false).toEqual(true, `action ${action} should be one of contains, equals or matches`);
         }
     }
 };

--- a/framework/step_functions/check/checkIfElementInsideParentElementEqualsMatchesTextOrValue2.js
+++ b/framework/step_functions/check/checkIfElementInsideParentElementEqualsMatchesTextOrValue2.js
@@ -12,7 +12,7 @@
  */
 
 const parseExpectedText = require('../common/parseExpectedText');
-const checkElement = (targetElementIdElement, targetElementIndex, targetElement, parentElementIndex, parentElement, falseCase, action, targetType, myExpectedText) => {
+const checkElement = async (targetElementIdElement, targetElementIndex, targetElement, parentElementIndex, parentElement, falseCase, action, targetType, myExpectedText) => {
     var retrivedValue;
     // Check for empty text
     if (typeof myExpectedText === 'undefined' && typeof falseCase === 'undefined') {
@@ -24,11 +24,11 @@ const checkElement = (targetElementIdElement, targetElementIndex, targetElement,
 
     switch (targetType) {
         case 'value':
-            if (typeof(targetElementIdElement) != 'undefined' && targetElementIdElement.isExisting()) {
-                if (targetElementIdElement.getTagName() == 'input') {
-                    retrivedValue = targetElementIdElement.getValue();
+            if (typeof(targetElementIdElement) != 'undefined' && await targetElementIdElement.isExisting()) {
+                if ((await targetElementIdElement.getTagName()) == 'input') {
+                    retrivedValue = await targetElementIdElement.getValue();
                 } else {
-                    retrivedValue = browser.getElementAttribute(targetElementIdElement, targetType);
+                    retrivedValue = await browser.getElementAttribute(targetElementIdElement, targetType);
                 }    
             } else {
                 retrivedValue = '';
@@ -36,7 +36,7 @@ const checkElement = (targetElementIdElement, targetElementIndex, targetElement,
             break;
         case 'text':
         case 'regex':
-            retrivedValue = typeof(targetElementIdElement) != 'undefined' && targetElementIdElement.isExisting() ? targetElementIdElement.getText() : '';
+            retrivedValue = typeof(targetElementIdElement) != 'undefined' && await targetElementIdElement.isExisting() ? await targetElementIdElement.getText() : '';
     }
 
     if (['existing', 'displayed', 'visible', 'enabled', 'clickable', 'focused', 'selected', 'checked'].includes(action)) {
@@ -46,13 +46,13 @@ const checkElement = (targetElementIdElement, targetElementIndex, targetElement,
         // element is still 'visible'.
         if (checkAction == 'isVisible') checkAction = 'isDisplayed';
         if (checkAction == 'isChecked') checkAction = 'isSelected';
-        const myResult = typeof(targetElementIdElement) != 'undefined' && targetElementIdElement.isExisting() && targetElementIdElement[checkAction]();
-        expect(myResult).toBe(!falseCase, `Failed expectation: the ${targetElementIndex} target element "${targetElement}" inside the ${parentElementIndex} parent element "${parentElement}" is ${falseCase} ${action}`);    
+        const myResult = typeof(targetElementIdElement) != 'undefined' && await targetElementIdElement.isExisting() && await targetElementIdElement[checkAction]();
+        await expect(myResult).toBe(!falseCase, `Failed expectation: the ${targetElementIndex} target element "${targetElement}" inside the ${parentElementIndex} parent element "${parentElement}" is ${falseCase} ${action}`);    
     } else if (falseCase) {
         switch (action) {
             case 'contain':
             case 'contains':
-                expect(retrivedValue).not.toContain(
+                await expect(retrivedValue).not.toContain(
                     myExpectedText,
                     `the ${targetElementIndex} target element "${targetElement}" inside the ${parentElementIndex} parent element "${parentElement}" should not contain ${targetType} ` +
                     `"${myExpectedText}"`
@@ -60,7 +60,7 @@ const checkElement = (targetElementIdElement, targetElementIndex, targetElement,
                 break;
             case 'equal':
             case 'equals':
-                expect(retrivedValue).not.toEqual(
+                await expect(retrivedValue).not.toEqual(
                     myExpectedText,
                     `the ${targetElementIndex} target element "${targetElement}" inside the ${parentElementIndex} parent element "${parentElement}" should not equal ${targetType} ` +
                     `"${myExpectedText}"`
@@ -68,7 +68,7 @@ const checkElement = (targetElementIdElement, targetElementIndex, targetElement,
                 break;
             case 'match':
             case 'matches':
-                expect(retrivedValue).not.toMatch(
+                await expect(retrivedValue).not.toMatch(
                     RegExp(myExpectedText),
                     `the ${targetElementIndex} target element "${targetElement}" inside the ${parentElementIndex} parent element "${parentElement}" should not match ${targetType} ` +
                     `"${myExpectedText}"`
@@ -79,7 +79,7 @@ const checkElement = (targetElementIdElement, targetElementIndex, targetElement,
         switch (action) {
             case 'contain':
             case 'contains':
-                expect(retrivedValue).toContain(
+                await expect(retrivedValue).toContain(
                     myExpectedText,
                     `the ${targetElementIndex} target element "${targetElement}" inside the ${parentElementIndex} parent element "${parentElement}" should contain ${targetType} ` +
                     `"${myExpectedText}"`
@@ -87,7 +87,7 @@ const checkElement = (targetElementIdElement, targetElementIndex, targetElement,
                 break;
             case 'equal':
             case 'equals':
-                expect(retrivedValue).toEqual(
+                await expect(retrivedValue).toEqual(
                     myExpectedText,
                     `the ${targetElementIndex} target element "${targetElement}" inside the ${parentElementIndex} parent element "${parentElement}" should equal ${targetType} ` +
                     `"${myExpectedText}"`
@@ -95,19 +95,19 @@ const checkElement = (targetElementIdElement, targetElementIndex, targetElement,
                 break;
             case 'match':
             case 'matches':
-                expect(retrivedValue).toMatch(
+                await expect(retrivedValue).toMatch(
                     RegExp(myExpectedText),
                     `the ${targetElementIndex} target element "${targetElement}" inside the ${parentElementIndex} parent element "${parentElement}" should match ${targetType} ` +
                     `"${myExpectedText}"`
                 );        
                 break;
             default:
-                expect(false).toEqual(true, `action ${action} should be one of contains, equals or matches`);
+                await expect(false).toEqual(true, `action ${action} should be one of contains, equals or matches`);
         }
     }
 }
 
-module.exports = (targetElementIndex, targetElement, parentElementIndex, parentElement, containsTheText, falseCase, action, targetType, expectedText) => {
+module.exports = async (targetElementIndex, targetElement, parentElementIndex, parentElement, containsTheText, falseCase, action, targetType, expectedText) => {
     const myExpectedText = parseExpectedText(expectedText);
     const myTargetElement = parseExpectedText(targetElement);
     const myParentElement = parseExpectedText(parentElement);
@@ -117,20 +117,27 @@ module.exports = (targetElementIndex, targetElement, parentElementIndex, parentE
 
     var targetElementIdElement;
     if (myParentElement) {
-        $(myParentElement).waitForExist();
-        const myFilteredParentElement = $$(myParentElement).filter(elem => elem.getText().includes(myContainsTheText));
+        await (await $(myParentElement)).waitForExist();
+        const myParentElementList = await $$(myParentElement);
+        const myFilteredParentElement = [];
+        for (const myParentElem of myParentElementList) {
+            if ((await myParentElem.getText()).includes(myContainsTheText)) {
+                myFilteredParentElement.push(myParentElem);
+            }
+        }
         if (parentElementIndexInt >= 0) {
-            targetElementIdElement = myFilteredParentElement[parentElementIndexInt].$$(myTargetElement)[targetElementIndexInt];
-            checkElement(targetElementIdElement, targetElementIndex, myTargetElement, parentElementIndex, myParentElement, falseCase, action, targetType, myExpectedText);
+            targetElementIdElement = (await myFilteredParentElement[parentElementIndexInt].$$(myTargetElement))[targetElementIndexInt];
+            await checkElement(targetElementIdElement, targetElementIndex, myTargetElement, parentElementIndex, myParentElement, falseCase, action, targetType, myExpectedText);
         } else {
-            myFilteredParentElement.forEach((pElement, pIndex) => {
-                targetElementIdElement = $$(pElement.selector)[pIndex].$$(myTargetElement)[targetElementIndexInt];
-                checkElement(targetElementIdElement, targetElementIndex, myTargetElement, pIndex + 1, myParentElement, falseCase, action, targetType, myExpectedText);    
-            });
+            for (let pIndex = 0; pIndex < myFilteredParentElement.length; pIndex++) {
+                const pElement = myFilteredParentElement[pIndex];
+                targetElementIdElement = (await (await $$(pElement.selector))[pIndex].$$(myTargetElement))[targetElementIndexInt];
+                await checkElement(targetElementIdElement, targetElementIndex, myTargetElement, pIndex + 1, myParentElement, falseCase, action, targetType, myExpectedText);    
+            }
         }
     } else {
-        targetElementIdElement = $$(myTargetElement)[targetElementIndexInt];
-        checkElement(targetElementIdElement, targetElementIndex, myTargetElement, parentElementIndex, myParentElement, falseCase, action, targetType, myExpectedText);
+        targetElementIdElement = (await $$(myTargetElement))[targetElementIndexInt];
+        await checkElement(targetElementIdElement, targetElementIndex, myTargetElement, parentElementIndex, myParentElement, falseCase, action, targetType, myExpectedText);
     }
 };
 

--- a/framework/step_functions/check/checkIfParentElementEqualsMatchesTextOrValue.js
+++ b/framework/step_functions/check/checkIfParentElementEqualsMatchesTextOrValue.js
@@ -12,7 +12,7 @@
 const { debug } = require('request/request');
 const parseExpectedText = require('../common/parseExpectedText');
 
-const checkElement = (parentElement, childElement, falseCase, action, targetType, myExpectedText) => {
+const checkElement = async (parentElement, childElement, falseCase, action, targetType, myExpectedText) => {
     var retrivedValue;
     // Check for empty text
     if (typeof myExpectedText === 'undefined' && typeof falseCase === 'undefined') {
@@ -24,11 +24,11 @@ const checkElement = (parentElement, childElement, falseCase, action, targetType
 
     switch (targetType) {
         case 'value':
-            if (typeof(parentElement) != 'undefined' && parentElement.isExisting()) {
-                if (parentElement.getTagName() == 'input') {
-                    retrivedValue = parentElement.getValue();
+            if (typeof(parentElement) != 'undefined' && await parentElement.isExisting()) {
+                if ((await parentElement.getTagName()) == 'input') {
+                    retrivedValue = await parentElement.getValue();
                 } else {
-                    retrivedValue = browser.getElementAttribute(parentElement, targetType);
+                    retrivedValue = await browser.getElementAttribute(parentElement, targetType);
                 }    
             } else {
                 retrivedValue = '';
@@ -36,7 +36,7 @@ const checkElement = (parentElement, childElement, falseCase, action, targetType
             break;
         case 'text':
         case 'regex':
-            retrivedValue = typeof(parentElement) != 'undefined' && parentElement.isExisting() ? parentElement.getText() : '';
+            retrivedValue = typeof(parentElement) != 'undefined' && await parentElement.isExisting() ? await parentElement.getText() : '';
     }
 
     if (['existing', 'displayed', 'visible', 'enabled', 'clickable', 'focused', 'selected', 'checked'].includes(action)) {
@@ -44,13 +44,13 @@ const checkElement = (parentElement, childElement, falseCase, action, targetType
         // "is visible" = CSS-visible (isDisplayed), not in-viewport
         if (checkAction == 'isVisible') checkAction = 'isDisplayed';
         if (checkAction == 'isChecked') checkAction = 'isSelected';
-        const myResult = typeof(parentElement) != 'undefined' && parentElement.isExisting() && parentElement[checkAction]();
-        expect(myResult).toBe(!falseCase, `Failed expectation: the parent element "${parentElement}" that contains the childelement "${childElement}" is ${falseCase} ${action}`);    
+        const myResult = typeof(parentElement) != 'undefined' && await parentElement.isExisting() && await parentElement[checkAction]();
+        await expect(myResult).toBe(!falseCase, `Failed expectation: the parent element "${parentElement}" that contains the childelement "${childElement}" is ${falseCase} ${action}`);    
     } else if (falseCase) {
         switch (action) {
             case 'contain':
             case 'contains':
-                expect(retrivedValue).not.toContain(
+                await expect(retrivedValue).not.toContain(
                     myExpectedText,
                     `the parent element "${parentElement}" that contains the childelement "${childElement}" should not contain ${targetType} ` +
                     `"${myExpectedText}"`
@@ -58,7 +58,7 @@ const checkElement = (parentElement, childElement, falseCase, action, targetType
                 break;
             case 'equal':
             case 'equals':
-                expect(retrivedValue).not.toEqual(
+                await expect(retrivedValue).not.toEqual(
                     myExpectedText,
                     `the parent element "${parentElement}" that contains the childelement "${childElement}" should not equal ${targetType} ` +
                     `"${myExpectedText}"`
@@ -66,7 +66,7 @@ const checkElement = (parentElement, childElement, falseCase, action, targetType
                 break;
             case 'match':
             case 'matches':
-                expect(retrivedValue).not.toMatch(
+                await expect(retrivedValue).not.toMatch(
                     RegExp(myExpectedText),
                     `the parent element "${parentElement}" that contains the childelement "${childElement}" should not match ${targetType} ` +
                     `"${myExpectedText}"`
@@ -77,7 +77,7 @@ const checkElement = (parentElement, childElement, falseCase, action, targetType
         switch (action) {
             case 'contain':
             case 'contains':
-                expect(retrivedValue).toContain(
+                await expect(retrivedValue).toContain(
                     myExpectedText,
                     `the parent element "${parentElement}" that contains the childelement "${childElement}" should contain ${targetType} ` +
                     `"${myExpectedText}"`
@@ -85,7 +85,7 @@ const checkElement = (parentElement, childElement, falseCase, action, targetType
                 break;
             case 'equal':
             case 'equals':
-                expect(retrivedValue).toEqual(
+                await expect(retrivedValue).toEqual(
                     myExpectedText,
                     `the parent element "${parentElement}" that contains the childelement "${childElement}" should equal ${targetType} ` +
                     `"${myExpectedText}"`
@@ -93,24 +93,24 @@ const checkElement = (parentElement, childElement, falseCase, action, targetType
                 break;
             case 'match':
             case 'matches':
-                expect(retrivedValue).toMatch(
+                await expect(retrivedValue).toMatch(
                     RegExp(myExpectedText),
                     `the parent element "${parentElement}" that contains the childelement "${childElement}" should match ${targetType} ` +
                     `"${myExpectedText}"`
                 );        
                 break;
             default:
-                expect(false).toEqual(true, `action ${action} should be one of contains, equals or matches`);
+                await expect(false).toEqual(true, `action ${action} should be one of contains, equals or matches`);
         }
     }
 }
 
-const findElement = (nthTarget, parentElement, childElement, falseCase, action, targetType, myExpectedText) => {
+const findElement = async (nthTarget, parentElement, childElement, falseCase, action, targetType, myExpectedText) => {
     const myElementIndex = parseInt(nthTarget) || 1;
-    const elementList = $$(parentElement);
+    const elementList = await $$(parentElement);
     var findResult;
     for (i=0; i<elementList.length; i++) {
-        if (elementList[i].$(childElement).isExisting()) {
+        if (await (await elementList[i].$(childElement)).isExisting()) {
             if (myElementIndex <= 1) {
                 findResult = elementList[i];
                 break;
@@ -122,8 +122,8 @@ const findElement = (nthTarget, parentElement, childElement, falseCase, action, 
     return findResult;
 }
 
-module.exports = (nthTarget, parentElement, childElement, falseCase, action, targetType, myExpectedText) => {
-    const targetParentElement = findElement(nthTarget, parentElement, childElement, falseCase, action, targetType, myExpectedText);
-    checkElement(targetParentElement, childElement, falseCase, action, targetType, myExpectedText);
+module.exports = async (nthTarget, parentElement, childElement, falseCase, action, targetType, myExpectedText) => {
+    const targetParentElement = await findElement(nthTarget, parentElement, childElement, falseCase, action, targetType, myExpectedText);
+    await checkElement(targetParentElement, childElement, falseCase, action, targetType, myExpectedText);
 };
 

--- a/framework/step_functions/check/checkIsOpenedInNewWindow.js
+++ b/framework/step_functions/check/checkIsOpenedInNewWindow.js
@@ -4,15 +4,15 @@
  * @param  {String}   obsolete    Indicator for the type (window or tab) unused
  */
 /* eslint-disable no-unused-vars */
-module.exports = (expectedUrl, obsolete) => {
+module.exports = async (expectedUrl, obsolete) => {
 /* eslint-enable no-unused-vars */
     /**
      * All the current window handles
      * @type {Object}
      */
-    const windowHandles = browser.getWindowHandles();
+    const windowHandles = await browser.getWindowHandles();
 
-    expect(windowHandles).not.toHaveLength(1, 'A popup was not opened');
+    await expect(windowHandles).not.toHaveLength(1, 'A popup was not opened');
 
     /**
      * The last opened window handle
@@ -21,18 +21,18 @@ module.exports = (expectedUrl, obsolete) => {
     const lastWindowHandle = windowHandles.slice(-1);
 
     // Make sure we focus on the last opened window handle
-    browser.switchToWindow(lastWindowHandle[0]);
+    await browser.switchToWindow(lastWindowHandle[0]);
 
     /**
      * Get the URL of the current browser window
      * @type {String}
      */
-    const windowUrl = browser.getUrl();
+    const windowUrl = await browser.getUrl();
 
-    expect(windowUrl).toContain(
+    await expect(windowUrl).toContain(
         expectedUrl,
         'The popup has a incorrect getUrl'
     );
 
-    browser.closeWindow();
+    await browser.closeWindow();
 };

--- a/framework/step_functions/check/checkModal.js
+++ b/framework/step_functions/check/checkModal.js
@@ -4,7 +4,7 @@
  *                               confirmbox or prompt)
  * @param  {String}   falseState Whether to check if the modal was opened or not
  */
-module.exports = (modalType, falseState) => {
+module.exports = async (modalType, falseState) => {
     /**
      * The text of the prompt
      * @type {String}
@@ -12,10 +12,10 @@ module.exports = (modalType, falseState) => {
     let promptText = '';
 
     try {
-        promptText = browser.getAlertText();
+        promptText = await browser.getAlertText();
 
         if (!!falseState) {
-            expect(promptText).to.not
+            await expect(promptText).to.not
                 .equal(
                     null,
                     `A ${modalType} was opened when it shouldn't`
@@ -23,7 +23,7 @@ module.exports = (modalType, falseState) => {
         }
     } catch (e) {
         if (!!!falseState) {
-            expect(promptText).to
+            await expect(promptText).to
                 .equal(
                     null,
                     `A ${modalType} was not opened when it should have been`

--- a/framework/step_functions/check/checkModalText.js
+++ b/framework/step_functions/check/checkModalText.js
@@ -6,23 +6,23 @@
  * @param  {String}   expectedText  The text to check against
  */
 const assert = require('assert');
-module.exports = (modalType, falseState, expectedText) => {
+module.exports = async (modalType, falseState, expectedText) => {
     try {
         /**
          * The text of the current modal
          * @type {String}
          */
-        const text = browser.getAlertText();
+        const text = await browser.getAlertText();
         console.log(text)
 
         if (!!falseState) {
-            expect(text).not.toEqual(
+            await expect(text).not.toEqual(
                 expectedText,
                 `Expected the text of ${modalType} not to equal ` +
                 `"${expectedText}"`
             );
         } else {
-            expect(text).toEqual(
+            await expect(text).toEqual(
                 expectedText,
                 `Expected the text of ${modalType} to equal ` +
                 `"${expectedText}", instead found "${text}"`

--- a/framework/step_functions/check/checkNewWindow.js
+++ b/framework/step_functions/check/checkNewWindow.js
@@ -4,16 +4,16 @@
  * @param  {String}   falseCase Whether to check if a new window/tab was opened
  *                              or not
  */
-module.exports = (obsolete, falseCase) => {
+module.exports = async (obsolete, falseCase) => {
     /**
      * The handles of all open windows/tabs
      * @type {Object}
      */
-    const windowHandles = browser.getWindowHandles();
+    const windowHandles = await browser.getWindowHandles();
 
     if (falseCase) {
-        expect(windowHandles.length).toEqual(1, 'A new window should not have been opened');
+        await expect(windowHandles.length).toEqual(1, 'A new window should not have been opened');
     } else {
-        expect(windowHandles.length).not.toEqual(1, 'A new window has been opened');
+        await expect(windowHandles.length).not.toEqual(1, 'A new window has been opened');
     }
 };

--- a/framework/step_functions/check/checkOffset.js
+++ b/framework/step_functions/check/checkOffset.js
@@ -6,7 +6,7 @@
  * @param  {String}   expectedPosition  The position to check against
  * @param  {String}   axis              The axis to check on (x or y)
  */
-module.exports = (elem, falseCase, expectedPosition, axis) => {
+module.exports = async (elem, falseCase, expectedPosition, axis) => {
     /**
      * Get the location of the element on the given axis
      * @type {[type]}
@@ -14,7 +14,7 @@ module.exports = (elem, falseCase, expectedPosition, axis) => {
     // getLocation may return a sub-pixel value (e.g. 1084.59375 vs an expected
     // CSS position of 1084). Compare within a small tolerance so sub-pixel
     // rendering does not fail an otherwise-correct position check.
-    const location = browser.$(elem).getLocation(axis);
+    const location = await (await browser.$(elem)).getLocation(axis);
     const tolerance = 1; // allow up to 1px sub-pixel drift
 
     /**
@@ -29,13 +29,13 @@ module.exports = (elem, falseCase, expectedPosition, axis) => {
     }
     const matches = Math.abs(location - intExpectedPosition) <= tolerance;
     if (falseCase) {
-        expect(matches).toBe(false,
+        await expect(matches).toBe(false,
                 `Element "${elem}" should not be positioned at ` +
                 `${intExpectedPosition}px on the ${axis} axis, but was found ` +
                 `at ${location}px`
             );
     } else {
-        expect(matches).toBe(true,
+        await expect(matches).toBe(true,
                 `Element "${elem}" should be positioned at ` +
                 `${intExpectedPosition}px on the ${axis} axis, but was found ` +
                 `at ${location}px`

--- a/framework/step_functions/check/checkProperty.js
+++ b/framework/step_functions/check/checkProperty.js
@@ -12,7 +12,7 @@
 
 const parseExpectedText = require('../common/parseExpectedText');
 
-module.exports = (isCSS, attrName, selector, action, falseCase, expectedValue) => {
+module.exports = async (isCSS, attrName, selector, action, falseCase, expectedValue) => {
     const  mySelector = parseExpectedText(selector);
     var  myExpectedValue = parseExpectedText(expectedValue);
     /**
@@ -31,7 +31,7 @@ module.exports = (isCSS, attrName, selector, action, falseCase, expectedValue) =
      * The actual attribute value
      * @type {Mixed}
      */
-    let attributeValue = $(mySelector)[command](attrName);
+    let attributeValue = await (await $(mySelector))[command](attrName);
 
     // eslint-disable-next-line
     myExpectedValue = isFinite(myExpectedValue) ?
@@ -51,7 +51,7 @@ module.exports = (isCSS, attrName, selector, action, falseCase, expectedValue) =
         switch (action) {
             case 'be':
             case 'is':
-                expect(attributeValue).not.toEqual(
+                await expect(attributeValue).not.toEqual(
                     myExpectedValue,
                     `${attrType}: ${attrName} of mySelector "${mySelector}" should not be ` +
                     `"${myExpectedValue}"`
@@ -59,7 +59,7 @@ module.exports = (isCSS, attrName, selector, action, falseCase, expectedValue) =
                 break;
             case 'contain':
             case 'contains':
-                expect(attributeValue).not.toContain(
+                await expect(attributeValue).not.toContain(
                     myExpectedValue,
                     `${attrType}: ${attrName} of mySelector "${mySelector}" should not contain ` +
                     `"${myExpectedValue}"`
@@ -67,7 +67,7 @@ module.exports = (isCSS, attrName, selector, action, falseCase, expectedValue) =
                 break;
             case 'match':
             case 'matches':
-                expect(attributeValue).not.toMatch(
+                await expect(attributeValue).not.toMatch(
                     RegExp(myExpectedValue),
                     `${attrType}: ${attrName} of mySelector "${mySelector}" should not match ` +
                     `"${myExpectedValue}"`
@@ -78,7 +78,7 @@ module.exports = (isCSS, attrName, selector, action, falseCase, expectedValue) =
         switch (action) {
             case 'be':
             case 'is':
-                expect(attributeValue).toEqual(
+                await expect(attributeValue).toEqual(
                     myExpectedValue,
                     `${attrType}: ${attrName} of mySelector "${mySelector}" should be ` +
                     `"${myExpectedValue}"`
@@ -86,7 +86,7 @@ module.exports = (isCSS, attrName, selector, action, falseCase, expectedValue) =
                 break;
             case 'contain':
             case 'contains':
-                expect(attributeValue).toContain(
+                await expect(attributeValue).toContain(
                     myExpectedValue,
                     `${attrType}: ${attrName} of mySelector "${mySelector}" should contain ` +
                     `"${myExpectedValue}"`
@@ -94,7 +94,7 @@ module.exports = (isCSS, attrName, selector, action, falseCase, expectedValue) =
                 break;
             case 'match':
             case 'matches':
-                expect(attributeValue).toMatch(
+                await expect(attributeValue).toMatch(
                     RegExp(myExpectedValue),
                     `${attrType}: ${attrName} of mySelector "${mySelector}" should match ` +
                     `"${myExpectedValue}"`

--- a/framework/step_functions/check/checkTitle.js
+++ b/framework/step_functions/check/checkTitle.js
@@ -9,7 +9,7 @@
 
 const parseExpectedText = require('../common/parseExpectedText');
 
-module.exports = (falseCase, action, type, expectedText) => {
+module.exports = async (falseCase, action, type, expectedText) => {
     /**
      * The expected text to validate against
      * @type {String}
@@ -34,14 +34,14 @@ module.exports = (falseCase, action, type, expectedText) => {
         boolFalseCase = true;
     }
 
-    const retrivedTitle = browser.getTitle();
+    const retrivedTitle = await browser.getTitle();
     // console.log(`${type} : ${retrivedTitle}`)
 
     if (boolFalseCase) {
         switch (action) {
             case 'contain':
             case 'contains':
-                expect(retrivedTitle).not.toContain(
+                await expect(retrivedTitle).not.toContain(
                     myExpectedText,
                     `page title does not contain ${type} ` +
                     `"${myExpectedText}"`
@@ -49,7 +49,7 @@ module.exports = (falseCase, action, type, expectedText) => {
                 break;
             case 'equal':
             case 'equals':
-                expect(retrivedTitle).not.toEqual(
+                await expect(retrivedTitle).not.toEqual(
                     myExpectedText,
                     `page title does not equal ${type} ` +
                     `"${myExpectedText}"`
@@ -57,20 +57,20 @@ module.exports = (falseCase, action, type, expectedText) => {
                 break;
             case 'match':
             case 'matches':
-                expect(retrivedTitle).not.toMatch(
+                await expect(retrivedTitle).not.toMatch(
                     RegExp(myExpectedText),
                     `page title does not match ${type} ` +
                     `"${myExpectedText}"`
                 );        
                 break;
             default:
-                expect(false).toBe(true, `action ${action} should be one of contains, equals or matches`);
+                await expect(false).toBe(true, `action ${action} should be one of contains, equals or matches`);
         }
     } else {
         switch (action) {
             case 'contain':
             case 'contains':
-                expect(retrivedTitle).toContain(
+                await expect(retrivedTitle).toContain(
                     myExpectedText,
                     `page title does contain ${type} ` +
                     `"${myExpectedText}"`
@@ -78,7 +78,7 @@ module.exports = (falseCase, action, type, expectedText) => {
                 break;
             case 'equal':
             case 'equals':
-                expect(retrivedTitle).toEqual(
+                await expect(retrivedTitle).toEqual(
                     myExpectedText,
                     `page title does equal ${type} ` +
                     `"${myExpectedText}"`
@@ -86,14 +86,14 @@ module.exports = (falseCase, action, type, expectedText) => {
                 break;
             case 'match':
             case 'matches':
-                expect(retrivedTitle).toMatch(
+                await expect(retrivedTitle).toMatch(
                     RegExp(myExpectedText),
                     `page title does match ${type} ` +
                     `"${myExpectedText}"`
                 );        
                 break;
             default:
-                expect(false).toBe(true, `action ${action} should be one of contains, equals or matches`);
+                await expect(false).toBe(true, `action ${action} should be one of contains, equals or matches`);
         }
     }
 }

--- a/framework/step_functions/check/checkURL.js
+++ b/framework/step_functions/check/checkURL.js
@@ -6,13 +6,13 @@
  * @param  {String}   expectedText The value to match against
  */
 const parseExpectedText = require('../common/parseExpectedText');
-module.exports = (target, falseCase, action, expectedText) => {
+module.exports = async (target, falseCase, action, expectedText) => {
     const myExpectedText = parseExpectedText(expectedText);
     /**
      * The URL of the current browser window
      * @type {String}
      */
-    const currentUrl = browser.getUrl();
+    const currentUrl = await browser.getUrl();
     const currentUrlProtocol = (currentUrl.includes('://')) ? currentUrl.split('://')[0] : '';
     const currentUrlHost = (currentUrl.includes('://')) ? currentUrl.split('://')[1].split('/')[0].split(':')[0] : '';
     const currentUrlHostPort = (currentUrl.includes('://')) ? currentUrl.split('://')[1].split('/')[0].split(':')[1] : '';
@@ -40,7 +40,7 @@ module.exports = (target, falseCase, action, expectedText) => {
         switch (action) {
             case 'be':
             case 'is':
-                expect(myTestTarget).not.toEqual(
+                await expect(myTestTarget).not.toEqual(
                     myExpectedText,
                     `The current ${target} should not be ` +
                     `"${myExpectedText}"`
@@ -48,7 +48,7 @@ module.exports = (target, falseCase, action, expectedText) => {
                 break;
             case 'contain':
             case 'contains':
-                expect(myTestTarget).not.toContain(
+                await expect(myTestTarget).not.toContain(
                     myExpectedText,
                     `The current ${target} should not contain ` +
                     `"${myExpectedText}"`
@@ -56,7 +56,7 @@ module.exports = (target, falseCase, action, expectedText) => {
                 break;
             case 'match':
             case 'matches':
-                expect(myTestTarget).not.toMatch(
+                await expect(myTestTarget).not.toMatch(
                     RegExp(myExpectedText),
                     `The current ${target} should not match ` +
                     `"${myExpectedText}"`
@@ -67,7 +67,7 @@ module.exports = (target, falseCase, action, expectedText) => {
         switch (action) {
             case 'be':
             case 'is':
-                expect(myTestTarget).toEqual(
+                await expect(myTestTarget).toEqual(
                     myExpectedText,
                     `The current ${target} should be ` +
                     `"${myExpectedText}"`
@@ -75,7 +75,7 @@ module.exports = (target, falseCase, action, expectedText) => {
                 break;
             case 'contain':
             case 'contains':
-                expect(myTestTarget).toContain(
+                await expect(myTestTarget).toContain(
                     myExpectedText,
                     `The current ${target} should contain ` +
                     `"${myExpectedText}"`
@@ -83,7 +83,7 @@ module.exports = (target, falseCase, action, expectedText) => {
                 break;
             case 'match':
             case 'matches':
-                expect(myTestTarget).toMatch(
+                await expect(myTestTarget).toMatch(
                     RegExp(myExpectedText),
                     `The current ${target} should match ` +
                     `"${myExpectedText}"`

--- a/framework/step_functions/check/checkWithinViewport.js
+++ b/framework/step_functions/check/checkWithinViewport.js
@@ -4,20 +4,20 @@
  * @param  {String}   falseCase Whether to check if the element is visible
  *                              within the current viewport or not
  */
-module.exports = (element, falseCase) => {
+module.exports = async (element, falseCase) => {
     /**
      * The state of visibility of the given element inside the viewport
      * @type {Boolean}
      */
-    const isVisible = browser.$(element).isDisplayedInViewport();
+    const isVisible = await (await browser.$(element)).isDisplayedInViewport();
 
     if (falseCase) {
-        expect(isVisible).not.toBe(
+        await expect(isVisible).not.toBe(
                 true,
                 `Expected element "${element}" to be outside the viewport`
             );
     } else {
-        expect(isVisible).toBe(
+        await expect(isVisible).toBe(
                 true,
                 `Expected element "${element}" to be inside the viewport`
             );

--- a/framework/step_functions/check/compareText.js
+++ b/framework/step_functions/check/compareText.js
@@ -5,26 +5,26 @@
  *                              elements match or not
  * @param  {String}   element2  Element selector for the second element
  */
-module.exports = (element1, falseCase, element2) => {
+module.exports = async (element1, falseCase, element2) => {
     /**
      * The text of the first element
      * @type {String}
      */
-    const text1 = browser.$(element1).getText();
+    const text1 = await (await browser.$(element1)).getText();
 
     /**
      * The text of the second element
      * @type {String}
      */
-    const text2 = browser.$(element2).getText();
+    const text2 = await (await browser.$(element2)).getText();
 
     if (falseCase) {
-        expect(text1).not.toEqual(
+        await expect(text1).not.toEqual(
             text2,
             `Expected text not to be "${text1}"`
         );
     } else {
-        expect(text1).toEqual(
+        await expect(text1).toEqual(
             text2,
             `Expected text to be "${text1}" but found "${text2}"`
         );

--- a/framework/step_functions/check/isEnabled.js
+++ b/framework/step_functions/check/isEnabled.js
@@ -7,14 +7,14 @@
  *                                 or not
  */
 const parseExpectedText = require('../common/parseExpectedText');
-module.exports = (partOf, element, waitAction, falseCase) => {
+module.exports = async (partOf, element, waitAction, falseCase) => {
     const myElement = parseExpectedText(element);
     const myPartOf = partOf || 'some';
     if (waitAction == 'becomes') {
         const ms = 10000;
-        browser.waitForEnabled(myElement, ms, !!falseCase);    
+        await browser.waitForEnabled(myElement, ms, !!falseCase);    
     }
-    var isEnabled = browser.$(myElement).isEnabled();
+    var isEnabled = await (await browser.$(myElement)).isEnabled();
     if (typeof isEnabled != 'boolean') {
         switch (myPartOf) {
             default:
@@ -28,8 +28,8 @@ module.exports = (partOf, element, waitAction, falseCase) => {
     }
 
     if (falseCase) {
-        expect(isEnabled).not.toEqual(true, `Expected ${myPartOf} of element "${myElement}" not to be enabled`);
+        await expect(isEnabled).not.toEqual(true, `Expected ${myPartOf} of element "${myElement}" not to be enabled`);
     } else {
-        expect(isEnabled).toEqual(true, `Expected ${myPartOf} of element "${myElement}" to be enabled`);
+        await expect(isEnabled).toEqual(true, `Expected ${myPartOf} of element "${myElement}" to be enabled`);
     }
 };

--- a/framework/step_functions/check/isVisible.js
+++ b/framework/step_functions/check/isVisible.js
@@ -6,14 +6,14 @@
  * @param  {String}   falseCase    Check for a visible or a hidden element
  */
 const parseExpectedText = require('../common/parseExpectedText');
-module.exports = (partOf, element, waitAction, falseCase) => {
+module.exports = async (partOf, element, waitAction, falseCase) => {
     const myElement = parseExpectedText(element);
     const myPartOf = partOf || 'some';
     if (waitAction == 'becomes') {
-        browser.$(myElement).waitForDisplayed(10000, !!falseCase);  
+        await (await browser.$(myElement)).waitForDisplayed(10000, !!falseCase);  
     }
-    browser.pause(1000);
-    const isVisible = browser.$(myElement).isDisplayed();
+    await browser.pause(1000);
+    const isVisible = await (await browser.$(myElement)).isDisplayed();
     if (typeof isVisible != 'boolean') {
         switch (myPartOf) {
             default:
@@ -27,8 +27,8 @@ module.exports = (partOf, element, waitAction, falseCase) => {
     }
 
     if (falseCase) {
-        expect(isVisible).not.toEqual(true, `Expected ${myPartOf} of element "${myElement}" not to be visible`);
+        await expect(isVisible).not.toEqual(true, `Expected ${myPartOf} of element "${myElement}" not to be visible`);
     } else {
-        expect(isVisible).toEqual(true, `Expected ${myPartOf} of element "${myElement}" to be visible`);
+        await expect(isVisible).toEqual(true, `Expected ${myPartOf} of element "${myElement}" to be visible`);
     }
 };

--- a/framework/support/hooks.js
+++ b/framework/support/hooks.js
@@ -89,7 +89,7 @@ const frameworkHooks = {
    * cucumber framework hooks
    **/ 
 
-   beforeFeature: function(uri, feature) {
+   beforeFeature: async function(uri, feature) {
     console.log(`Feature: ${feature.document.feature.name}\n`);
     currentScenarioName = '';
     currentStepNumber = 0;
@@ -121,14 +121,14 @@ const frameworkHooks = {
     }
   },
 
-  beforeScenario: function(context) {
+  beforeScenario: async function(context) {
     console.log(`Scenario: ${context.pickle.name}\n`);
     const scenarioName = context.pickle.name;
     currentScenarioName = scenarioName;
     currentStepNumber = 0;
-    browser.windowHandleMaximize();
+    await browser.windowHandleMaximize();
     // browser.setTimeouts(implicit, pageLoad, script)
-    browser.setTimeouts(null, null, 3600*1000);
+    await browser.setTimeouts(null, null, 3600*1000);
   },
 
   beforeStep: function(step, context) {
@@ -140,7 +140,7 @@ const frameworkHooks = {
     }
   },
 
-  afterStep: function(step, context, {error, result, duration, passed}) {
+  afterStep: async function(step, context, {error, result, duration, passed}) {
     // to be done for real steps
     if (step.text.length > 0) {
       // start recording
@@ -175,12 +175,12 @@ const frameworkHooks = {
 
       // show browser log
       if (process.env.BROWSERLOG == 1) {
-        browser_session.showErrorLog(browser);
+        await browser_session.showErrorLog(browser);
       }
     }
   },
 
-  afterScenario: function(context) {
+  afterScenario: async function(context) {
     // console.log(context);
     const resultStatus = context.result.status;
     const feature_uri = context.gherkinDocument.uri;
@@ -190,7 +190,7 @@ const frameworkHooks = {
     } else {
       currentScenarioStatus = 'Failed'
       console.log('browser error log:');
-      browser_session.showErrorLog(browser);
+      await browser_session.showErrorLog(browser);
     }
     const remarkText = (process.env.SCREENREMARK == 0) ? '' : `Scenario ${currentScenarioStatus}: ${currentScenarioName}`;
     const remarkColor = (currentScenarioStatus == 'Passed') ? 'green' : 'red';
@@ -204,7 +204,7 @@ const frameworkHooks = {
       framework_libs.stopRecording(currentScenarioName);
     }
     if (process.env.MOVIE == 1) {
-      framework_libs.renameRecording(currentScenarioName, currentScenarioStatus, currentStepNumber);
+      await framework_libs.renameRecording(currentScenarioName, currentScenarioStatus, currentStepNumber);
     }
 
     // process tags for report attachement
@@ -235,14 +235,14 @@ const frameworkHooks = {
 
     // need to perform these steps before tear down RDP
     if (process.env.SSHHOST && process.env.SSHPORT) {
-      changeBrowserZoom(100);
+      await changeBrowserZoom(100);
     }
 
     // need this pause for screenshots rename procss to finish
-    browser.pause(1000);
+    await browser.pause(1000);
   },
   
-  afterFeature: function(uri, feature) {
+  afterFeature: async function(uri, feature) {
     if (process.env.SSHHOST && process.env.SSHPORT) {
       try {
         framework_libs.stopRdesktop();

--- a/framework/support/module_hooks.js
+++ b/framework/support/module_hooks.js
@@ -17,135 +17,135 @@ if (fs.existsSync(`${ProjectPath}/${TestDir}/${TestModule}/support/hooks.js`)) {
 }
 
 exports.hooks = {
-  onPrepare: function (config, capabilities) {
-    if (frameworkHooks.onPrepare) frameworkHooks.onPrepare(config, capabilities);
-    if (projectHooks.onPrepare) projectHooks.onPrepare(config, capabilities);
-    if (localHooks.onPrepare) localHooks.onPrepare(config, capabilities);
+  onPrepare: async function (config, capabilities) {
+    if (frameworkHooks.onPrepare) await frameworkHooks.onPrepare(config, capabilities);
+    if (projectHooks.onPrepare) await projectHooks.onPrepare(config, capabilities);
+    if (localHooks.onPrepare) await localHooks.onPrepare(config, capabilities);
   },
 
-  onWorkerStart: function (cid, caps, specs, args, execArgv) {
-    if (frameworkHooks.onWorkerStart) frameworkHooks.onWorkerStart(cid, caps, specs, args, execArgv);
-    if (projectHooks.onWorkerStart) projectHooks.onWorkerStart(cid, caps, specs, args, execArgv);
-    if (localHooks.onWorkerStart) localHooks.onWorkerStart(cid, caps, specs, args, execArgv);
+  onWorkerStart: async function (cid, caps, specs, args, execArgv) {
+    if (frameworkHooks.onWorkerStart) await frameworkHooks.onWorkerStart(cid, caps, specs, args, execArgv);
+    if (projectHooks.onWorkerStart) await projectHooks.onWorkerStart(cid, caps, specs, args, execArgv);
+    if (localHooks.onWorkerStart) await localHooks.onWorkerStart(cid, caps, specs, args, execArgv);
   },
 
-  beforeSession: function (config, capabilities, specs) {
-    if (frameworkHooks.beforeSession) frameworkHooks.beforeSession(config, capabilities, specs);
-    if (projectHooks.beforeSession) projectHooks.beforeSession(config, capabilities, specs);
-    if (localHooks.beforeSession) localHooks.beforeSession(config, capabilities, specs);
+  beforeSession: async function (config, capabilities, specs) {
+    if (frameworkHooks.beforeSession) await frameworkHooks.beforeSession(config, capabilities, specs);
+    if (projectHooks.beforeSession) await projectHooks.beforeSession(config, capabilities, specs);
+    if (localHooks.beforeSession) await localHooks.beforeSession(config, capabilities, specs);
   },
 
-  before: function (capabilities, specs) {
-    if (frameworkHooks.before) frameworkHooks.before(capabilities, specs);
-    if (projectHooks.before) projectHooks.before(capabilities, specs);
-    if (localHooks.before) localHooks.before(capabilities, specs);
+  before: async function (capabilities, specs) {
+    if (frameworkHooks.before) await frameworkHooks.before(capabilities, specs);
+    if (projectHooks.before) await projectHooks.before(capabilities, specs);
+    if (localHooks.before) await localHooks.before(capabilities, specs);
   },
 
-  beforeSuite: function (suite) {
-    if (frameworkHooks.beforeSuite) frameworkHooks.beforeSuite(suite);
-    if (projectHooks.beforeSuite) projectHooks.beforeSuite(suite);
-    if (localHooks.beforeSuite) localHooks.beforeSuite(suite);
+  beforeSuite: async function (suite) {
+    if (frameworkHooks.beforeSuite) await frameworkHooks.beforeSuite(suite);
+    if (projectHooks.beforeSuite) await projectHooks.beforeSuite(suite);
+    if (localHooks.beforeSuite) await localHooks.beforeSuite(suite);
   },
 
-  beforeHook: function (test, context/*, stepData, world*/) {
-    if (frameworkHooks.beforeHook) frameworkHooks.beforeHook(test, context/*, stepData, world*/);
-    if (projectHooks.beforeHook) projectHooks.beforeHook(test, context/*, stepData, world*/);
-    if (localHooks.beforeHook) localHooks.beforeHook(test, context/*, stepData, world*/);
+  beforeHook: async function (test, context/*, stepData, world*/) {
+    if (frameworkHooks.beforeHook) await frameworkHooks.beforeHook(test, context/*, stepData, world*/);
+    if (projectHooks.beforeHook) await projectHooks.beforeHook(test, context/*, stepData, world*/);
+    if (localHooks.beforeHook) await localHooks.beforeHook(test, context/*, stepData, world*/);
   },
 
-  afterHook: function (test, context, { error, result, duration, passed, retries }/*, stepData, world*/) {
-    if (frameworkHooks.afterHook) frameworkHooks.afterHook(test, context, { error, result, duration, passed, retries }/*, stepData, world*/);
-    if (projectHooks.afterHook) projectHooks.afterHook(test, context, { error, result, duration, passed, retries }/*, stepData, world*/);
-    if (localHooks.afterHook) localHooks.afterHook(test, context, { error, result, duration, passed, retries }/*, stepData, world*/);
+  afterHook: async function (test, context, { error, result, duration, passed, retries }/*, stepData, world*/) {
+    if (frameworkHooks.afterHook) await frameworkHooks.afterHook(test, context, { error, result, duration, passed, retries }/*, stepData, world*/);
+    if (projectHooks.afterHook) await projectHooks.afterHook(test, context, { error, result, duration, passed, retries }/*, stepData, world*/);
+    if (localHooks.afterHook) await localHooks.afterHook(test, context, { error, result, duration, passed, retries }/*, stepData, world*/);
   },
 
-  beforeTest: function (test, context) {
-    if (frameworkHooks.beforeTest) frameworkHooks.beforeTest(test, context);
-    if (projectHooks.beforeTest) projectHooks.beforeTest(test, context);
-    if (localHooks.beforeTest) localHooks.beforeTest(test, context);
+  beforeTest: async function (test, context) {
+    if (frameworkHooks.beforeTest) await frameworkHooks.beforeTest(test, context);
+    if (projectHooks.beforeTest) await projectHooks.beforeTest(test, context);
+    if (localHooks.beforeTest) await localHooks.beforeTest(test, context);
   },
 
-  beforeCommand: function (commandName, args) {
-    if (frameworkHooks.beforeCommand) frameworkHooks.beforeCommand(commandName, args);
-    if (projectHooks.beforeCommand) projectHooks.beforeCommand(commandName, args);
-    if (localHooks.beforeCommand) localHooks.beforeCommand(commandName, args);
+  beforeCommand: async function (commandName, args) {
+    if (frameworkHooks.beforeCommand) await frameworkHooks.beforeCommand(commandName, args);
+    if (projectHooks.beforeCommand) await projectHooks.beforeCommand(commandName, args);
+    if (localHooks.beforeCommand) await localHooks.beforeCommand(commandName, args);
   },
 
-  beforeFeature: function (uri, feature) {
-    if (frameworkHooks.beforeFeature) frameworkHooks.beforeFeature(uri, feature);
-    if (projectHooks.beforeFeature) projectHooks.beforeFeature(uri, feature);
-    if (localHooks.beforeFeature) localHooks.beforeFeature(uri, feature);
+  beforeFeature: async function (uri, feature) {
+    if (frameworkHooks.beforeFeature) await frameworkHooks.beforeFeature(uri, feature);
+    if (projectHooks.beforeFeature) await projectHooks.beforeFeature(uri, feature);
+    if (localHooks.beforeFeature) await localHooks.beforeFeature(uri, feature);
   },
 
-  beforeScenario: function (context) {
-    if (frameworkHooks.beforeScenario) frameworkHooks.beforeScenario(context);
-    if (projectHooks.beforeScenario) projectHooks.beforeScenario(context);
-    if (localHooks.beforeScenario) localHooks.beforeScenario(context);
+  beforeScenario: async function (context) {
+    if (frameworkHooks.beforeScenario) await frameworkHooks.beforeScenario(context);
+    if (projectHooks.beforeScenario) await projectHooks.beforeScenario(context);
+    if (localHooks.beforeScenario) await localHooks.beforeScenario(context);
   },
 
-  beforeStep: function (step, context) {
-    if (frameworkHooks.beforeStep) frameworkHooks.beforeStep(step, context);
-    if (projectHooks.beforeStep) projectHooks.beforeStep(step, context);
-    if (localHooks.beforeStep) localHooks.beforeStep(step, context);
+  beforeStep: async function (step, context) {
+    if (frameworkHooks.beforeStep) await frameworkHooks.beforeStep(step, context);
+    if (projectHooks.beforeStep) await projectHooks.beforeStep(step, context);
+    if (localHooks.beforeStep) await localHooks.beforeStep(step, context);
   },
 
-  afterStep: function (step, context, {error, result, duration, passed}) {
-    if (frameworkHooks.afterStep) frameworkHooks.afterStep(step, context, {error, result, duration, passed});
-    if (projectHooks.afterStep) projectHooks.afterStep(step, context, {error, result, duration, passed});
-    if (localHooks.afterStep) localHooks.afterStep(step, context, {error, result, duration, passed});
+  afterStep: async function (step, context, {error, result, duration, passed}) {
+    if (frameworkHooks.afterStep) await frameworkHooks.afterStep(step, context, {error, result, duration, passed});
+    if (projectHooks.afterStep) await projectHooks.afterStep(step, context, {error, result, duration, passed});
+    if (localHooks.afterStep) await localHooks.afterStep(step, context, {error, result, duration, passed});
   },
 
-  afterScenario: function (context) {
-    if (frameworkHooks.afterScenario) frameworkHooks.afterScenario(context);
-    if (projectHooks.afterScenario) projectHooks.afterScenario(context);
-    if (localHooks.afterScenario) localHooks.afterScenario(context);
+  afterScenario: async function (context) {
+    if (frameworkHooks.afterScenario) await frameworkHooks.afterScenario(context);
+    if (projectHooks.afterScenario) await projectHooks.afterScenario(context);
+    if (localHooks.afterScenario) await localHooks.afterScenario(context);
   },
 
-  afterFeature: function (uri, feature) {
-    if (frameworkHooks.afterFeature) frameworkHooks.afterFeature(uri, feature);
-    if (projectHooks.afterFeature) projectHooks.afterFeature(uri, feature);
-    if (localHooks.afterFeature) localHooks.afterFeature(uri, feature);
+  afterFeature: async function (uri, feature) {
+    if (frameworkHooks.afterFeature) await frameworkHooks.afterFeature(uri, feature);
+    if (projectHooks.afterFeature) await projectHooks.afterFeature(uri, feature);
+    if (localHooks.afterFeature) await localHooks.afterFeature(uri, feature);
   },
 
-  afterCommand: function (commandName, args, result, error) {
-    if (frameworkHooks.afterCommand) frameworkHooks.afterCommand(commandName, args, result, error);
-    if (projectHooks.afterCommand) projectHooks.afterCommand(commandName, args, result, error);
-    if (localHooks.afterCommand) localHooks.afterCommand(commandName, args, result, error);
+  afterCommand: async function (commandName, args, result, error) {
+    if (frameworkHooks.afterCommand) await frameworkHooks.afterCommand(commandName, args, result, error);
+    if (projectHooks.afterCommand) await projectHooks.afterCommand(commandName, args, result, error);
+    if (localHooks.afterCommand) await localHooks.afterCommand(commandName, args, result, error);
   },
 
-  afterTest: function (test, context, { error, result, duration, passed, retries }) {
-    if (frameworkHooks.afterTest) frameworkHooks.afterTest(test, context, { error, result, duration, passed, retries });
-    if (projectHooks.afterTest) projectHooks.afterTest(test, context, { error, result, duration, passed, retries });
-    if (localHooks.afterTest) localHooks.afterTest(test, context, { error, result, duration, passed, retries });
+  afterTest: async function (test, context, { error, result, duration, passed, retries }) {
+    if (frameworkHooks.afterTest) await frameworkHooks.afterTest(test, context, { error, result, duration, passed, retries });
+    if (projectHooks.afterTest) await projectHooks.afterTest(test, context, { error, result, duration, passed, retries });
+    if (localHooks.afterTest) await localHooks.afterTest(test, context, { error, result, duration, passed, retries });
   },
 
-  afterSuite: function (suite) {
-    if (frameworkHooks.afterSuite) frameworkHooks.afterSuite(suite);
-    if (projectHooks.afterSuite) projectHooks.afterSuite(suite);
-    if (localHooks.afterSuite) localHooks.afterSuite(suite);
+  afterSuite: async function (suite) {
+    if (frameworkHooks.afterSuite) await frameworkHooks.afterSuite(suite);
+    if (projectHooks.afterSuite) await projectHooks.afterSuite(suite);
+    if (localHooks.afterSuite) await localHooks.afterSuite(suite);
   },
 
-  after: function (result, capabilities, specs) {
-    if (frameworkHooks.after) frameworkHooks.after(result, capabilities, specs);
-    if (projectHooks.after) projectHooks.after(result, capabilities, specs);
-    if (localHooks.after) localHooks.after(result, capabilities, specs);
+  after: async function (result, capabilities, specs) {
+    if (frameworkHooks.after) await frameworkHooks.after(result, capabilities, specs);
+    if (projectHooks.after) await projectHooks.after(result, capabilities, specs);
+    if (localHooks.after) await localHooks.after(result, capabilities, specs);
   },
 
-  afterSession: function (config, capabilities, specs) {
-    if (frameworkHooks.afterSession) frameworkHooks.afterSession(config, capabilities, specs);
-    if (projectHooks.afterSession) projectHooks.afterSession(config, capabilities, specs);
-    if (localHooks.afterSession) localHooks.afterSession(config, capabilities, specs);
+  afterSession: async function (config, capabilities, specs) {
+    if (frameworkHooks.afterSession) await frameworkHooks.afterSession(config, capabilities, specs);
+    if (projectHooks.afterSession) await projectHooks.afterSession(config, capabilities, specs);
+    if (localHooks.afterSession) await localHooks.afterSession(config, capabilities, specs);
   },
 
-  onComplete: function (exitCode, config, capabilities, results) {
-    if (frameworkHooks.onComplete) frameworkHooks.onComplete(exitCode, config, capabilities, results);
-    if (projectHooks.onComplete) projectHooks.onComplete(exitCode, config, capabilities, results);
-    if (localHooks.onComplete) localHooks.onComplete(exitCode, config, capabilities, results);
+  onComplete: async function (exitCode, config, capabilities, results) {
+    if (frameworkHooks.onComplete) await frameworkHooks.onComplete(exitCode, config, capabilities, results);
+    if (projectHooks.onComplete) await projectHooks.onComplete(exitCode, config, capabilities, results);
+    if (localHooks.onComplete) await localHooks.onComplete(exitCode, config, capabilities, results);
   },
 
-  onReload: function(oldSessionId, newSessionId) {
-    if (frameworkHooks.onReload) frameworkHooks.onReload(oldSessionId, newSessionId);
-    if (projectHooks.onReload) projectHooks.onReload(oldSessionId, newSessionId);
-    if (localHooks.onReload) localHooks.onReload(oldSessionId, newSessionId);
+  onReload: async function(oldSessionId, newSessionId) {
+    if (frameworkHooks.onReload) await frameworkHooks.onReload(oldSessionId, newSessionId);
+    if (projectHooks.onReload) await projectHooks.onReload(oldSessionId, newSessionId);
+    if (localHooks.onReload) await localHooks.onReload(oldSessionId, newSessionId);
   },
 }

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "@wdio/local-runner": "7.7.7",
     "@wdio/selenium-standalone-service": "7.7.7",
     "@wdio/spec-reporter": "7.7.7",
-    "@wdio/sync": "7.7.7",
     "cucumber-html-reporter": "^5.4.0",
     "cucumber-junit": "^1.7.1",
     "expect-webdriverio": "^3.1.0",

--- a/test-projects/autobdd-test/dev/bootstrap-dev.sh
+++ b/test-projects/autobdd-test/dev/bootstrap-dev.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Dev-loop bootstrap for autobdd-test against the mounted working-tree AutoBDD.
 # Run AFTER any `npm install` in AutoBDD, which wipes native build artifacts
-# (fibers) and selenium-standalone drivers. Safe to re-run idempotently.
+# (selenium-standalone drivers). Safe to re-run idempotently.
 #
 # Usage:  AutoBDD_DEV_ROOT=/abs/path/to/AutoBDD bash dev/bootstrap-dev.sh
 set -euo pipefail
@@ -17,13 +17,7 @@ fi
 AUTODIR="$(cd "$ABDD" && pwd)"
 echo "AutoBDD working tree: $AUTODIR"
 
-# 1. Rebuild fibers (needed by @wdio/sync on Node 12; no prebuilt binary).
-#    Only inside the container (Node 12) — host Node 22 would produce a wrong ABI.
-if [ -d "$AUTODIR/node_modules/fibers" ] && [ "${AUTOBDD_DEV_MOUNT:-}" = "1" ]; then
-  echo "* rebuilding fibers for Node $(node -v)..."
-  (cd "$AUTODIR/node_modules/fibers" && node-gyp rebuild >/dev/null 2>&1)
-  node -e "require('$AUTODIR/node_modules/fibers')" && echo "  fibers OK"
-fi
+# 1. (removed) @wdio/sync + fibers no longer used (async conversion, Phase 3).
 
 # 2. Ensure selenium-standalone drivers exist (npm install wipes .selenium/)
 DRIVER_VERSION="${CHROME_DRIVER_VERSION:-96.0.4664.45}"

--- a/test-projects/autobdd-test/e2e-test/support/steps/when.js
+++ b/test-projects/autobdd-test/e2e-test/support/steps/when.js
@@ -2,9 +2,9 @@ const { When } = require('@cucumber/cucumber');
 
 When(
     /^:project: I scroll to the element "([^"]*)?"$/,
-        (elem) => {
-            $(elem).isExisting();
-            $(elem).scrollIntoView();
-            $(elem).isDisplayed();
+        async (elem) => {
+            await (await $(elem)).isExisting();
+            await (await $(elem)).scrollIntoView();
+            await (await $(elem)).isDisplayed();
         }
     );


### PR DESCRIPTION
Combined PR from `xywang68/AutoBDD:master` (supersedes #151 and #153). Steps toward v4.0.0 per `docs/upgrade-plan.md`.

## Phase 2 — dependency hygiene (Node-12/wdio7 runtime)
- Remove dead/builtin deps and Node-core shadow shims (`assert`, `child_process`, `path`), unused reporters/allure/devtools devDeps.
- Pin unbounded `>=` ranges; pin Node-12-safe `inquirer@8.2.6`; drop npm8-only `overrides`.
- Delete orphaned `framework/scripts/old-findTargetImage.js`.
- Fix monorepo dev-mount harness paths; ignore vendored node-gyp build output.

## Phase 3 — sync→async (drop `@wdio/sync` + `fibers`)
- Drop `@wdio/sync` devDep; remove fibers rebuild from `dev/bootstrap-dev.sh`.
- Hooks (`hooks.js`, `module_hooks.js`) async; libs (`browser_session`, `vcenter_session`, `fs_session`, `framework_libs.renameRecording`) async where they touch the protocol/`browser.pause`.
- All step functions/files webdriver-using handlers async with awaited commands. wdio7 async returns `Promise<Element>` from `$`/`browser.$`, so element fetches are awaited before method calls (`(await $(sel)).click()`, `(await $$(sel))[i]`); async `forEach` rewritten to awaited `for...of`.
- e2e-test project step file converted async + fetch-first.

## Gate (local rebuild `xyteam/autobdd:3.0.0`, async, no fibers)
- e2e **15/15** (single 1, parallel 14, auto 14), 0 failed
- cypress 3/3, jest 3/3, pytest 6 + 1 xfail (intended CAL-1234), k6 0% failed

Merge authority: xyteam/AutoBDD maintainers.