### PR TITLE
v2.4.0 fix: make the old wdio7 stack run against modern Chrome

### DIFF
--- a/.docker/autobdd-image.dockerfile
+++ b/.docker/autobdd-image.dockerfile
@@ -25,6 +25,28 @@ RUN mkdir -p /root/Downloads && \
     npm run --loglevel=error clean && \
     rm -rf /tmp/chrome_profile_* /tmp/download_*
 
+# Bake the Selenium standalone server + a chromedriver matching the installed Chrome.
+# The old wdio7 selenium-standalone cannot provision a driver for modern Chrome: its
+# download source caps at ChromeDriver 114, and its zip extractor drops any entry with
+# a '/', so chrome-for-testing's nested chromedriver-linux64/chromedriver would extract
+# to nothing. The framework therefore runs with skipSeleniumInstall and uses these
+# baked artifacts at the paths selenium-standalone computes.
+RUN set -e; \
+    SELDIR=/root/Projects/AutoBDD/node_modules/selenium-standalone/.selenium; \
+    CV=$(google-chrome --version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'); \
+    echo "baking selenium + chromedriver ${CV}"; \
+    mkdir -p "$SELDIR/selenium-server/3.141.59" "$SELDIR/chromedriver/${CV}-x64"; \
+    curl -fsSL "https://github.com/SeleniumHQ/selenium/releases/download/selenium-3.141.59/selenium-server-standalone-3.141.59.jar" \
+        -o "$SELDIR/selenium-server/3.141.59/selenium-server.jar"; \
+    curl -fsSL "https://storage.googleapis.com/chrome-for-testing-public/${CV}/linux64/chromedriver-linux64.zip" \
+        -o /tmp/cd.zip; \
+    ( cd /tmp && unzip -o -q cd.zip ); \
+    cp /tmp/chromedriver-linux64/chromedriver "$SELDIR/chromedriver/${CV}-x64/chromedriver"; \
+    chmod +x "$SELDIR/chromedriver/${CV}-x64/chromedriver"; \
+    ln -sf "$SELDIR/chromedriver/${CV}-x64/chromedriver" /usr/local/bin/chromedriver; \
+    /usr/local/bin/chromedriver --version; \
+    rm -rf /tmp/cd.zip /tmp/chromedriver-linux64
+
 # copy preset ubuntu system env
 COPY .docker/autobdd.root /
 RUN chmod +x /root/.bash_profile /root/autobdd-run.startup.sh /root/autobdd-dev.startup.sh 

--- a/README.md
+++ b/README.md
@@ -1,125 +1,56 @@
-> **Version (v3.0):** This is **AutoBDD v3.0** (`package.json` `3.0.0`, docker image
-> `xyteam/autobdd:3.0.0`). v3.0 is the aligned baseline for the four-repo project
-> set and is verified to keep **AutoBDD working together with the
-> [AutoBDD-example](https://github.com/xyteam/AutoBDD-example) and
-> [autobdd-test](https://github.com/xyteam/autobdd-test) repos** (and xySikulixApi) —
-> all on v3.0. This v3.0 set is the base going forward; a future effort consolidates
-> these repos and upgrades dependencies together.
+# AutoBDD v2.4.0
 
-#### AutoBDD v3: converted to webdriverio (wdio 7 on Node 12)
+**AutoBDD v2.4.0** (`package.json` `2.4.0`, docker image `xyteam/autobdd:2.4.0`).
 
-#### TLDR:
+> **Purpose.** The goal of this release is to **re-activate the AutoBDD v2.3.0 line
+> into a working, reproducible state** that serves as the corrected base going
+> forward. The earlier label "v3.0.0" was applied prematurely to this codebase;
+> it has been re-versioned here as **v2.4.0** to keep the version history honest.
+> A future **v3.0.0** (runtime re-baseline on Node 20 / WebdriverIO 9) continues
+> from this base.
 
-```
-mkdir -p ~/Projects; cd ~/Projects; \
-git clone https://github.com/xyteam/AutoBDD-example.git; \
-cd AutoBDD-example/docker; \
-docker-compose run --rm autobdd-example-run "--parallel=4 --screenshot=3 --movie=1 --rerunfailed=1 --reportpath=test1"
+AutoBDD is a BDD Automation Framework — Powerful, Flexible and Easy-to-Use:
 
-google-chrome ~/Projects/AutoBDD-example/test-results/test1/index.html
-```
-## AutoBDD (v3)
-
-  BDD Automation Framework
-
-  Powerful, Flexible and Easy-to-Use BDD Automation Framework
-
-  * Powerful - Automate anything you can see and operate on any desktop, local or remote, Web or non-Web.
-
-  * Flexible - Runs on any local desktop, cloud system or CI/CD system, single thread or in parallel.
-
-  * Easy-To-Use - Write test cases in plain English sentences, single command execution anywhere.
+* Powerful — automate anything you can see and operate on any desktop, local or remote, Web or non-Web.
+* Flexible — runs on any local desktop, cloud system or CI/CD system, single thread or in parallel.
+* Easy-To-Use — write test cases in plain English, single-command execution anywhere.
 
 #### Simple to use
 
-  * AutoBDD lets you focus on your test.
-  
-  * Everything else will automagically work out for you.
+* AutoBDD lets you focus on your test; everything else works out for you.
+* Download [AutoBDD-example](https://github.com/xyteam/AutoBDD-example) and try it.
+* Rename AutoBDD-example as your own project.
 
-  * Just download AutoBDD-example and give it a try:
+#### Under the hood
 
-  **[xyteam/AutoBDD-example](https://github.com/xyteam/AutoBDD-example)**
+##### Platform
 
-  * And rename AutoBDD-example project as your own.
+* Linux base (Ubuntu 20.04)
+  * xvfb desktop environment — real web browser, real file system, keyboard-mouse-screen control
+  * development tools (nodejs, python, java, etc.)
+* Screen, Keyboard and Mouse libraries
+  * sikulixapi (screen and images)
+  * robot-js (keyboard and mouse)
+  * tesseract-ocr (screen or browser image to text)
 
-#### Under the hood:
+##### Framework
 
-##### Platform:
+* Automation tools
+  * CI/CD runner — parallel test runner, automatic cucumber + junit report generator
+  * local development runner — full GUI (WYSIWYT), auto project mount, docker-compose up/down control
+* Popular 3rd-party libraries
+  * webdriverio (v7, on Node 12)
+  * cucumber-js
+  * HTML report with step screenshots and test-case movie
+  * rich pre-canned cucumber steps (150+)
+* Framework-provided libraries
+  * keyboard-mouse control (cucumber BDD statements and JS library)
+  * remote access (remote desktop, remote command console, remote filesystem)
 
-  * Linux Base (Ubuntu 20.04)
-    
-    * xvfb desktop environment
-    
-      *  real web browser
-    
-      *  real file system
-    
-      *  keyboard-mouse-screen control
-    
-    * development tools (nodejs, python, java, etc.)
-
-  * Screen, Keyboard and Mouse Libraries
-    
-    * sikulixapi (screen and images)
-    
-    * robot-js (keyboard and mouse)
-    
-    * tesseract-ocr (screen or browser image to text)
-
-##### Framework:
-
-  * Automation Tools
-    
-    * CI/CD Runner
-    
-      * parellel test runner
-    
-      * automatic cucumber and junit report generator
-    
-      * pre-canned runner control -- runner will handle docker image download and running automagically
-    
-    * Local Development Runner
-    
-      * full GUI - WYSIWYT -- what you see is what you test
-    
-      * auto project mount - WYWIWYT -- what you write is what you test
-    
-      * pre-canned runner control -- runner can be controlled with 2 simple docker-compose commands (up and down)
-  
-    * Popular 3rd Party Libraries
-  
-    * webdriverio (v7, on Node 12)
-  
-    * cucumber-js (v6)
-  
-    * HTML report with step screenshots and test case movie
-  
-    * very rich pre-canned cucumber steps (over 150 steps)
-  
-  * Framework Provided Libries
-  
-    * keyboard-mouse control
-  
-      * in cucumber BDD statements
-  
-      * in js library
-  
-    * remote access
-  
-      * remote desktop
-  
-      * remote command console
-  
-      * remote filesystem access
-    
 #### Special mentions
 
-  * Demo-App application and Precanned Cucumber-JS Steps are taken from **[webdriverio/cucumber-boilerplate](https://github.com/webdriverio/cucumber-boilerplate)**
-  
-  * Image Regognizing library is taken from **[RaiMan/SikuliX1](https://github.com/RaiMan/SikuliX1)**
-  
-  * Keyboard and Mouse control library is taken from **[octalmage/robotjs](https://github.com/octalmage/robotjs)**
-  
-  * Framework Control libraries are taken from **[webdriverio/webdriverio](https://github.com/webdriverio/webdriverio)** 
-  
-  * And many other open-source npm libraries listed in **[package.json](https://github.com/xyteam/AutoBDD/blob/master/package.json)**
+* Demo-App application and pre-canned Cucumber-JS steps are taken from **[webdriverio/cucumber-boilerplate](https://github.com/webdriverio/cucumber-boilerplate)**
+* Image-recognizing library is taken from **[RaiMan/SikuliX1](https://github.com/RaiMan/SikuliX1)**
+* Keyboard-and-mouse library is taken from **[octalmage/robotjs](https://github.com/octalmage/robotjs)**
+* Framework-control libraries are taken from **[webdriverio/webdriverio](https://github.com/webdriverio/webdriverio)**
+* Many other open-source npm libraries are listed in **package.json**.

--- a/framework/support/env.js
+++ b/framework/support/env.js
@@ -48,84 +48,15 @@ if (process.env.PLATFORM == 'Linux') {
     console.log(process.env.chromeVersion);
   }
   if (!process.env.chromeDriverVersion) {
-    switch (true) {
-      case / 7[012]\./.test(process.env.chromeVersion):
-        process.env.chromeDriverVersion = '2.46';
-        break;
-      case / 73\./.test(process.env.chromeVersion):
-        process.env.chromeDriverVersion = '73.0.3683.68';
-        break;
-      case / 74\./.test(process.env.chromeVersion):
-        process.env.chromeDriverVersion = '74.0.3729.6';
-        break;
-      case / 75\./.test(process.env.chromeVersion):
-        process.env.chromeDriverVersion = '75.0.3770.140';
-        break;
-      case / 76\./.test(process.env.chromeVersion):
-        process.env.chromeDriverVersion = '76.0.3809.126';
-        break;
-      case / 77\./.test(process.env.chromeVersion):
-        process.env.chromeDriverVersion = '77.0.3865.40';
-        break;
-      case / 78\./.test(process.env.chromeVersion):
-        process.env.chromeDriverVersion = '78.0.3904.105';
-        break;
-      case / 79\./.test(process.env.chromeVersion):
-        process.env.chromeDriverVersion = '79.0.3945.36';
-        break;
-      case / 80\./.test(process.env.chromeVersion):
-        process.env.chromeDriverVersion = '80.0.3987.106';
-        break;
-      case / 81\./.test(process.env.chromeVersion):
-        process.env.chromeDriverVersion = '81.0.4044.138';
-        break;
-      case / 83\./.test(process.env.chromeVersion):
-        process.env.chromeDriverVersion = '83.0.4103.39';
-        break;
-      case / 84\./.test(process.env.chromeVersion):
-        process.env.chromeDriverVersion = '84.0.4147.30';
-        break;
-      case / 85\./.test(process.env.chromeVersion):
-        process.env.chromeDriverVersion = '85.0.4183.87';
-        break;
-      case / 86\./.test(process.env.chromeVersion):
-        process.env.chromeDriverVersion = '86.0.4240.22';
-        break;
-      case / 87\./.test(process.env.chromeVersion):
-        process.env.chromeDriverVersion = '87.0.4280.88';
-        break;  
-      case / 88\./.test(process.env.chromeVersion):
-        process.env.chromeDriverVersion = '88.0.4324.96';
-        break;  
-      case / 89\./.test(process.env.chromeVersion):
-        process.env.chromeDriverVersion = '89.0.4389.23';
-        break;
-      case / 90\./.test(process.env.chromeVersion):
-        process.env.chromeDriverVersion = '90.0.4430.24';
-        break;
-      case / 91\./.test(process.env.chromeVersion):
-        process.env.chromeDriverVersion = '91.0.4472.101';
-        break;
-      case / 92\./.test(process.env.chromeVersion):
-        process.env.chromeDriverVersion = '92.0.4515.43';
-        break;
-      case / 93\./.test(process.env.chromeVersion):
-        process.env.chromeDriverVersion = '93.0.4577.63';
-        break;
-      case / 94\./.test(process.env.chromeVersion):
-        process.env.chromeDriverVersion = '94.0.4606.113';
-        break;      
-      case / 95\./.test(process.env.chromeVersion):
-        process.env.chromeDriverVersion = '95.0.4638.69';
-        break;
-      case / 96\./.test(process.env.chromeVersion):
-        process.env.chromeDriverVersion = '96.0.4664.45';
-        break;      
-      case / 97\./.test(process.env.chromeVersion):
-        process.env.chromeDriverVersion = '97.0.4692.36';
-        break;                    
-    }
-    console.log('Chrome Driver ' + process.env.chromeDriverVersion)  
+    // Match the chromedriver baked into the image (see .docker/autobdd-image.dockerfile).
+    // The old wdio7 selenium-standalone can no longer download a driver for modern
+    // Chrome (its source caps at ChromeDriver 114 and its zip extractor drops nested
+    // entries), so the image bakes a chromedriver matching the installed Chrome and
+    // this mirrors that version. Expected path:
+    //   .selenium/chromedriver/<chromeVersion>-<arch>/chromedriver
+    const chromeVerMatch = (process.env.chromeVersion || '').match(/(\d+\.\d+\.\d+\.\d+)/);
+    if (chromeVerMatch) process.env.chromeDriverVersion = chromeVerMatch[1];
+    console.log('Chrome Driver ' + (process.env.chromeDriverVersion || 'n/a'));
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "autobdd",
-  "version": "3.0.0",
+  "version": "2.4.0",
   "description": "BDD Automaiton",
   "scripts": {
     "test-init": ". ./.autoPathrc.sh && cd ./test-projects/autobdd-test && xvfb-runner.sh make e2e-single-runner",


### PR DESCRIPTION
## v2.4.0 fix: make the old wdio7 stack run against modern Chrome

**Problem.** AutoBDD-example against the built `xyteam/autobdd:2.4.0` ran **no tests** — all specs crashed:
```
session not created: This version of ChromeDriver only supports Chrome version 114
Current browser version is 153.0.8010.36
```
The v2.4.0 image installs current Chrome (153), but the old **wdio7 + selenium-standalone** stack cannot provision a matching driver:
- its download source (`chromedriver.storage.googleapis.com`) caps at **114**, and
- its zip extractor drops entries containing `/`, so chrome-for-testing's nested `chromedriver-linux64/chromedriver` extracts to nothing; and
- `onlyInstallMissingFiles` only skips on HTTP 304, so a baked driver can't short-circuit the download.

**Fix.**
- `.docker/autobdd-image.dockerfile`: bake the selenium-server jar (GitHub releases) **and** a chromedriver matching the installed Chrome, at the exact paths selenium-standalone computes (`.selenium/selenium-server/3.141.59/selenium-server.jar`, `.selenium/chromedriver/<chromeVer>-x64/chromedriver`), plus a `/usr/local/bin/chromedriver` symlink.
- `framework/support/env.js`: set `chromeDriverVersion` dynamically from the installed Chrome (was a hardcoded map ending at Chrome 97 that left it `undefined`), so the framework points at the baked driver. `skipSeleniumInstall` stays on; the selenium server spawns chromedriver per session, so parallel runs work.

**Validation.** AutoBDD-example against the rebuilt image: **740 passing / 4 failing / 1 skipped** (was: 0 ran, 42 crashed). Remaining 4 failures are genuine old-runtime assertions (`testdownloadtable`, `window`), not infrastructure.
