### PR TITLE
docs+ci: plan/status refresh, CHANGELOG, Chrome-version record, autobdd-test CI

### DIFF
--- a/.docker/autobdd-nodejs.dockerfile
+++ b/.docker/autobdd-nodejs.dockerfile
@@ -39,4 +39,10 @@ RUN \
     unzip -o /tmp/chromedriver_linux64.zip -d /tmp/cd && \
     install -m 0755 /tmp/cd/chromedriver-linux64/chromedriver /usr/local/bin/chromedriver && \
     rm -rf /tmp/chromedriver_linux64.zip /tmp/cd && \
-    echo "installed chrome ${CHROME_VER}, chromedriver ${DRIVER_URL}"
+    echo "installed chrome ${CHROME_VER}, chromedriver ${DRIVER_URL}" && \
+    # Record the resolved Chrome/chromedriver versions for traceability (Chrome is
+    # installed as "latest stable" and therefore floats at build time).
+    { echo "chrome=${CHROME_VER}"; \
+      echo "chromedriver=$(chromedriver --version 2>/dev/null | awk '{print $2}')"; \
+      echo "built=$(date -u +%Y-%m-%dT%H:%M:%SZ)"; } > /etc/autobdd-chrome-version && \
+    cat /etc/autobdd-chrome-version

--- a/.github/workflows/autobdd-test.yml
+++ b/.github/workflows/autobdd-test.yml
@@ -1,0 +1,54 @@
+name: autobdd-test
+
+# Run the AutBDD e2e gate (test-projects/autobdd-test) against the framework
+# code in this commit. The base runtime layers are the published images; only the
+# AutoBDD layer (framework + npm install + Oculix bake) is rebuilt from the commit,
+# so this tests the commit's framework code.
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+
+env:
+  AUTOBDD_VER: "3.0.0"
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Pull base runtime images
+        run: |
+          docker pull "xyteam/autobdd-nodejs:${AUTOBDD_VER}"
+          docker pull "xyteam/autobdd-ubuntu:${AUTOBDD_VER}"
+
+      - name: Build AutoBDD image from this commit
+        run: |
+          docker build \
+            --build-arg AUTOBDD_VERSION="${AUTOBDD_VER}" \
+            -t "xyteam/autobdd:${AUTOBDD_VER}" \
+            -f .docker/autobdd-image.dockerfile .
+
+      - name: Run autobdd-test e2e gate (baked image)
+        working-directory: test-projects/autobdd-test
+        env:
+          USER: runner
+          HOSTOS: Linux
+          USERID: "1001"
+          GROUPID: "1001"
+        run: |
+          docker compose -f docker-compose.docker.yml run --rm autobdd-test-run \
+            "xvfb-runner.sh make clean e2e-test"
+
+      - name: Upload test report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: autobdd-test-report
+          path: test-projects/autobdd-test/test-results/e2e-test/
+          if-no-files-found: warn
+          retention-days: 7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,65 @@
+# Changelog
+
+Release notes for AutoBDD. Images are published to Docker Hub as
+`xyteam/autobdd:<version>` (plus base layers `xyteam/autobdd-nodejs:<version>`,
+`xyteam/autobdd-ubuntu:<version>`). Test repos pull and run the image by version —
+see [README.md](README.md).
+
+Version tags use a `v`-prefix (`v2.4.0`, `v3.0.0`). The `1.0.x`/`2.1.0` tags predate
+the convention.
+
+## v3.0.0
+
+The runtime re-baseline — the continuation of v2.4.0.
+
+**Runtime**
+- Ubuntu 22.04 · Node 20 · Java 17 · Chrome + chromedriver on PATH.
+- WebdriverIO **9** (cucumber); runs with `docker compose` (Compose v2).
+- **Oculix 4.0.0** screen image matching + OCR (vendored `oculixapi-4.0.0-linux.jar`,
+  java-bridge on Java 17); native libs baked to `/opt/oculix-natives` with
+  `LD_LIBRARY_PATH`. System `tesseract`/`leptonica`/`opencv` removed from the image.
+- Dynamic driver-version reporting (reads the real `chromedriver --version`).
+
+**Image-match UX**
+- Restored flash-on-match — a red border over clear content (no opaque fill), visible
+  under Xvfb; ~1 s, tunable via `--flash`.
+- Flash in the step screenshot — the capture during a `FindImageTarget` step becomes
+  that step's screenshot, with the step-name watermark at the bottom, green for passed
+  / red for failed steps.
+- Baked (image) mode compose for `autobdd-test`.
+
+**Validation** — e2e gate green (29/29) on the rebuilt image, dev-mount and baked modes.
+
+**Notes** — the image installs the latest stable Chrome at build time (it floats); the
+resolved version is recorded at `/etc/autobdd-chrome-version` in the image.
+
+## v2.4.0
+
+The corrected **base**: re-activates the AutoBDD **v2.3.0** line into a working,
+reproducible state. (The previously-applied "v3.0.0" label on this baseline was
+premature and has been retracted; v3.0.0 now refers to the runtime re-baseline above.)
+
+**Runtime** — Node 14 · WebdriverIO 7 · Chrome (latest stable at build, e.g. 153).
+
+**Browser driver fix** — the legacy `selenium-standalone` can no longer provision a
+driver for modern Chrome (its source caps at ChromeDriver 114; its zip extractor drops
+nested entries; it only skips on HTTP 304). The image now bakes the selenium-server jar
+and a chromedriver **matching the installed Chrome** at the paths selenium-standalone
+computes, and `chromeDriverVersion` is detected dynamically. `skipSeleniumInstall`
+stays on; the server spawns chromedriver per session (parallel works).
+
+**Validation** — AutoBDD-example against the image: 740 passing / 4 failing / 1 skipped
+(was 0 ran).
+
+## v2.3.0
+
+The original pinned runtime: **Node 12.22.7 · Chrome 96 · WebdriverIO 7**. Documented
+for reference; not tagged in this repository.
+
+## Version matrix
+
+| Release | Chrome | WebdriverIO | Node |
+|---|---|---|---|
+| v2.3.0 | 96 | 7 | 12 |
+| v2.4.0 | modern (latest stable at build) | 7 | 14 |
+| v3.0.0 | modern (latest stable at build) | 9 | 20 |

--- a/docs/upgrade-plan.md
+++ b/docs/upgrade-plan.md
@@ -1,7 +1,30 @@
 # AutoBDD — Upgrade Plan (post-consolidation)
 
+## Status (current)
+
+The modern-stack re-baseline described by this plan (scripted below as "v4.0.0") has
+**shipped as v3.0.0**. Current state:
+
+* **`master` = v3.0.0** — Ubuntu 22.04 · Node 20 · Java 17 · WebdriverIO 9 · Oculix 4.0.0
+  (screen image matching + OCR). Tag `v3.0.0`, GitHub Release, and image
+  `xyteam/autobdd:3.0.0` published.
+* **`v2.4.0`** — the corrected **base**: the re-activated v2.3.0 line (Node 14 ·
+  WebdriverIO 7) made runnable against current Chrome. Tag `v2.4.0`, Release, and image
+  `xyteam/autobdd:2.4.0` published. v3.0.0 is the continuation of this base.
+* **OculiX cutover (Phase 6): done** — see issue #152. Two checklist items are deferred
+  as tracked follow-ups: **#160** (`OCR.globalOptions()` set once at bridge start) and
+  **#161** (migrate keyboard/mouse from `robotjs` to Oculix `Mouse`/`Key`).
+* **Future:** adopt **Octachorix** (Oculix's next OCR binding — ×2 throughput, absolute-path
+  library loading) in the Oculix release after 4.0.0.
+* **Tag convention:** releases use a `v`-prefix (`v2.4.0`, `v3.0.0`). Legacy tags
+  (`1.0.x`, `2.1.0`) predate the convention; no `v2.3.0` tag exists (its commit is not
+  reliably identifiable), so the released v2.3.0 runtime is documented, not tagged.
+* **Image reproducibility:** the image installs the **latest stable Chrome** at build
+  time (it floats). The build records the resolved version under
+  `/etc/autobdd-chrome-version` in the image (see `.docker/autobdd-nodejs.dockerfile`).
+
 > **Baseline:** AutoBDD is now a **single self-contained monorepo** on `master`
-> (`98e3bee`, v3.0.0). Phase-1 of the earlier effort folded `xySikulixApi` into
+> (the modern-stack baseline; originally `98e3bee`). Phase-1 of the earlier effort folded `xySikulixApi` into
 > `third_party/xysikulixapi` and the `autobdd-test` suite into
 > `test-projects/autobdd-test`. Verified green (per `98e3bee`) against the baked
 > `xyteam/autobdd:3.0.0` image: **all 15 e2e scenarios** (1 @Init + 14 across
@@ -14,8 +37,9 @@
 > with `autobdd-test` green**, is cut as a PR, merged by the user, and the next phase
 > only starts on the user's go-ahead.
 >
-> **Target release:** v4.0.0 on a modern stack (Ubuntu 22.04, Node 20 LTS, Java 17,
-> modern Chrome, WebdriverIO v9 async, Oculix-based screen bridge).
+> **Target release:** the modern stack (Ubuntu 22.04, Node 20 LTS, Java 17, modern
+> Chrome, WebdriverIO v9 async, Oculix-based screen bridge) — **shipped as v3.0.0**
+> (see Status above); this plan referred to it as "v4.0.0" while it was in flight.
 
 ---
 


### PR DESCRIPTION
Follow-ups from the v2.4.0/v3.0.0 work:

- **docs/upgrade-plan.md** — current Status section (v2.4.0 base → v3.0.0 shipped; OculiX cutover done per #152 with #160/#161 follow-ups; Octachorix future; `v`-prefix tag convention; image reproducibility), and reconcile the stale 'v4.0.0 target'.
- **CHANGELOG.md** — v3.0.0 + v2.4.0 entries, version matrix, tag convention.
- **.docker/autobdd-nodejs.dockerfile** — record the resolved Chrome/chromedriver version at `/etc/autobdd-chrome-version` (Chrome is installed as latest-stable and floats at build).
- **.github/workflows/autobdd-test.yml** — on push/PR to master, pull the published base images, rebuild the AutoBDD layer from the commit, and run the `autobdd-test` e2e gate (single/parallel/auto); uploads the report.

Validated locally: the workflow's baked autobdd-test command runs the full gate green (29/29).